### PR TITLE
Create file type key when the key is not existing, and use the key as class key, add SHChangeNotify to tell desktop to refresh after handler get registered

### DIFF
--- a/SharpShell/SharpShell/Interop/Shell32.cs
+++ b/SharpShell/SharpShell/Interop/Shell32.cs
@@ -229,6 +229,16 @@ namespace SharpShell.Interop
         public static extern int SHCreateDataObject(IntPtr pidlFolder, uint cidl, IntPtr apidl, IDataObject pdtInner, Guid riid,
             out IntPtr ppv);
 
+        /// <summary>
+        /// Notifies the system of an event that an application has performed. An application should use this function if it performs an action that may affect the Shell.
+        /// </summary>
+        /// <param name="wEventId">Describes the event that has occurred. Typically, only one event is specified at a time. If more than one event is specified, the values contained in the dwItem1 and dwItem2 parameters must be the same, respectively, for all specified events. This parameter can be one or more of the following values:</param>
+        /// <param name="uFlags">Flags that, when combined bitwise with SHCNF_TYPE, indicate the meaning of the dwItem1 and dwItem2 parameters. The uFlags parameter must be one of the following values.</param>
+        /// <param name="dwItem1">Optional. First event-dependent value.</param>
+        /// <param name="dwItem2">Optional. Second event-dependent value.</param>
+        [DllImport("shell32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern void SHChangeNotify(Int32 wEventId, UInt32 uFlags, IntPtr dwItem1, IntPtr dwItem2);
+
         public static Guid IID_IQueryAssociations = new Guid("{c46ca590-3c3f-11d2-bee6-0000f805ca57}");
         public static Guid IID_IShellFolder = new Guid("000214E6-0000-0000-C000-000000000046");
         public static Guid IID_IImageList = new Guid("46EB5926-582E-4017-9FDF-E8998DAA0950");
@@ -237,5 +247,6 @@ namespace SharpShell.Interop
         public static Guid IID_IContextMenu = new Guid("000214e4-0000-0000-c000-000000000046");
         public static Guid IID_IShellBrowser = new Guid("000214E2-0000-0000-C000-000000000046");
         public static Guid IID_IFolderView = new Guid("cde725b0-ccc9-4519-917e-325d72fab4ce");
+
     }
 }

--- a/SharpShell/SharpShell/ServerRegistration/ServerRegistrationManager.cs
+++ b/SharpShell/SharpShell/ServerRegistration/ServerRegistrationManager.cs
@@ -5,8 +5,7 @@ using System.Security.AccessControl;
 using Microsoft.Win32;
 using SharpShell.Attributes;
 using SharpShell.Extensions;
-using SharpShell.Diagnostics;
-using SharpShell.Interop;
+
 
 namespace SharpShell.ServerRegistration
 {
@@ -452,7 +451,6 @@ namespace SharpShell.ServerRegistration
                     } 
                     else 
                     {
-
                         //  Get the default icon.
                         var defaultIcon = defaultIconKey.GetValue(null, string.Empty).ToString();
 
@@ -760,7 +758,7 @@ namespace SharpShell.ServerRegistration
         /// <param name="server">The server.</param>
         /// <param name="registrationType">Type of the registration.</param>
         /// <exception cref="System.InvalidOperationException">Failed to open the Approved Extensions key.</exception>
-        public static void ApproveExtension(ISharpShellServer server, RegistrationType registrationType)
+        private static void ApproveExtension(ISharpShellServer server, RegistrationType registrationType)
         {
             //  Open the approved extensions key.
             using(var approvedKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, 
@@ -773,18 +771,6 @@ namespace SharpShell.ServerRegistration
 
                 //  Create an entry for the server.
                 approvedKey.SetValue(server.ServerClsid.ToRegistryString(), server.DisplayName);
-            }
-        }
-
-        public static void ApproveExtension(Type type, RegistrationType registrationType) {
-            using (var approvedKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine,
-                registrationType == RegistrationType.OS64Bit ? RegistryView.Registry64 : RegistryView.Registry32)
-                .OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved", RegistryKeyPermissionCheck.ReadWriteSubTree)) {
-                //  If we can't open the key, we're going to have problems.
-                if (approvedKey == null)
-                    throw new InvalidOperationException("Failed to open the Approved Extensions key.");
-                Logging.Log("Approve " + approvedKey.ToString() + "\\" + type.GUID.ToRegistryString());
-                approvedKey.SetValue(type.GUID.ToRegistryString(), "");
             }
         }
 

--- a/SharpShell/SharpShell/ServerRegistration/ServerRegistrationManager.cs
+++ b/SharpShell/SharpShell/ServerRegistration/ServerRegistrationManager.cs
@@ -447,7 +447,7 @@ namespace SharpShell.ServerRegistration
                     if (defaultIconKey == null)
                     {
                         // if not, we create the key.
-                        RegistryKey tempDefaultIconKey = classesKey.CreateSubKey(KeyName_DefaultIcon, RegistryKeyPermissionCheck.ReadWriteSubTree);
+                        RegistryKey tempDefaultIconKey = classesKey.CreateSubKey(className + @"\" + KeyName_DefaultIcon, RegistryKeyPermissionCheck.ReadWriteSubTree);
                         tempDefaultIconKey.SetValue(null, "%1");
                     } 
                     else 
@@ -577,10 +577,9 @@ namespace SharpShell.ServerRegistration
                             //  Open the file type key.
                             using (var fileTypeKey = classesKey.OpenSubKey(association))
                             {
-                                //  If the file type key is null, we create the key.
+                                //  If the file type key is null, create it.
                                 if (fileTypeKey == null) 
                                 {
-                                    Logging.Log("creating key for " + association);
                                     classesKey.CreateSubKey(association);
                                     // use the file type key as the class
                                     fileTypeClasses.Add(association);

--- a/SharpShell/SharpShell/SharpIconOverlayHandler/SharpIconOverlayHandler.cs
+++ b/SharpShell/SharpShell/SharpIconOverlayHandler/SharpIconOverlayHandler.cs
@@ -238,7 +238,7 @@ namespace SharpShell.SharpIconOverlayHandler
                                                   "being registered, it will not be used by Windows Explorer.");
 
                     //  Create the overlay key.
-                    using(var overlayKey = overlayIdentifiers.CreateSubKey(serverType.Name))
+                    using(var overlayKey = overlayIdentifiers.CreateSubKey(" " + serverType.Name))
                     {
                         //  If we don't have the overlay key, we've got a problem.
                         if(overlayKey == null)

--- a/SharpShell/SharpShell/SharpShellServer.cs
+++ b/SharpShell/SharpShell/SharpShellServer.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using SharpShell.Attributes;
 using SharpShell.Diagnostics;
 using SharpShell.ServerRegistration;
+using SharpShell.Interop;
 
 namespace SharpShell
 {
@@ -79,6 +80,8 @@ namespace SharpShell
 
             //  Execute the custom register function, if there is one.
             CustomRegisterFunctionAttribute.ExecuteIfExists(type, registrationType);
+
+            Shell32.SHChangeNotify(0x08000000, 0, IntPtr.Zero, IntPtr.Zero);
         }
 
         /// <summary>
@@ -106,6 +109,8 @@ namespace SharpShell
 
             //  Execute the custom unregister function, if there is one.
             CustomUnregisterFunctionAttribute.ExecuteIfExists(type, registrationType);
+
+            Shell32.SHChangeNotify(0x08000000, 0, IntPtr.Zero, IntPtr.Zero);
         }
         
         /// <summary>


### PR DESCRIPTION
see #83 
The file type key was made during the registration process.
And also create the defaultIcon key for Icon handler

@dwmkerr, I'm still using regasm to register dll so that I cannot catch the exception threw out from registration process, unless I rewrite the comregisterfunction. I mean we could have better idea than through exception there.
