### PR TITLE
Registration type override flags

### DIFF
--- a/SharpShell/Tools/ServerRegistrationManager/Actions/ShowHelpAction.cs
+++ b/SharpShell/Tools/ServerRegistrationManager/Actions/ShowHelpAction.cs
@@ -24,7 +24,7 @@ namespace ServerRegistrationManager.Actions
             //  Load the resource.
             using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
             {
-                if(stream == null)
+                if (stream == null)
                     throw new InvalidOperationException("Unable to access resource " + resourceName);
                 using (var reader = new StreamReader(stream))
                 {
@@ -39,6 +39,7 @@ namespace ServerRegistrationManager.Actions
             outputService.WriteMessage("    srm install <path to SharpShell server> <parameters>");
             outputService.WriteMessage("Parameters:");
             outputService.WriteMessage("    -codebase: Optional. Installs a server from a file location, not the GAC.");
+            outputService.WriteMessage("    -os[32|64]: Optional. Forces 32 bit or 64 bit installation (Ignores Environment.Is64BitOperatingSystem).");
             outputService.WriteMessage("");
             outputService.WriteMessage("To uninstall a server:");
             outputService.WriteMessage("    srm uninstall <path to SharpShell server>");

--- a/SharpShell/Tools/ServerRegistrationManager/Application.cs
+++ b/SharpShell/Tools/ServerRegistrationManager/Application.cs
@@ -58,6 +58,17 @@ namespace ServerRegistrationManager
             var target = args.Length > 1 ? args[1] : (string)null; // TODO tidy this up.
             var parameters = args.Skip(1);
 
+            //Allow user to override registrationType with -os32 or -os64
+            if (parameters.Any(p => p.Equals(ParameterOS32, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                registrationType = RegistrationType.OS32Bit;
+            }
+            else if (parameters.Any(p => p.Equals(ParameterOS64, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                registrationType = RegistrationType.OS64Bit;
+            }
+
+
             //  Based on the verb, perform the action.
             if (verb == VerbInstall)
                 InstallServer(target, registrationType, parameters.Any(p => p == ParameterCodebase));
@@ -85,7 +96,7 @@ namespace ServerRegistrationManager
                 outputService.WriteError("File '" + path + "' does not exist.", true);
                 return;
             }
-            
+
             //  Try and load the server types.
             IEnumerable<ISharpShellServer> serverTypes = null;
             try
@@ -204,5 +215,8 @@ namespace ServerRegistrationManager
         private const string VerbEnableEventLog = @"enableeventlog";
 
         private const string ParameterCodebase = @"-codebase";
+
+        private const String ParameterOS32 = @"-os32";
+        private const String ParameterOS64 = @"-os64";
     }
 }


### PR DESCRIPTION
Added the ability to override the registration type (OS32Bit/OS64Bit)
parameter in ServerRegistrationManager. (Needed for a shell extension
that had to be built as x86 only, but was being registered as x64 on 64
bit Windows installations).
