### PR TITLE
Support RegistrationNameAttribute on svr type specifying registry key name

### DIFF
--- a/SharpShell/SharpShell/Attributes/RegistrationNameAttribute.cs
+++ b/SharpShell/SharpShell/Attributes/RegistrationNameAttribute.cs
@@ -1,0 +1,51 @@
+﻿using System;
+
+namespace SharpShell.Attributes
+{
+    /// <summary>
+    /// Specify the registry key name under which a SharpShell server should be registered.
+    /// By default (without this attribute) a server is registered under the classname.
+    /// Since each server needs its own registry key name, this attribute does not inherit.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class RegistrationNameAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegistrationNameAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The registry key name under which the SharpShell server should be registered. Cannot be null or whitespace.</param>
+        public RegistrationNameAttribute(string registrationName)
+        {
+            if (string.IsNullOrWhiteSpace(registrationName))
+                throw new ArgumentException("registrationName");
+            RegistrationName = registrationName;
+        }
+
+        /// <summary>
+        /// Gets the registry key name under which to register the SharpShell server.
+        /// </summary>
+        public string RegistrationName { get; private set; }
+
+        /// <summary>
+        /// Gets the registration name for a type if defined.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>The registration name of the type if defined, or <value>null</value> otherwise.</returns>
+        public static string GetRegistrationName(Type type)
+        {
+            foreach (RegistrationNameAttribute attribute in type.GetCustomAttributes(typeof(RegistrationNameAttribute), false))
+                return attribute.RegistrationName;
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the registration name for a type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>The registration name of the type if defined, or <value>type.Name</value> otherwise.</returns>
+        public static string GetRegistrationNameOrTypeName(Type type)
+        {
+            return GetRegistrationName(type) ?? type.Name;
+        }
+    }
+}

--- a/SharpShell/SharpShell/SharpIconOverlayHandler/SharpIconOverlayHandler.cs
+++ b/SharpShell/SharpShell/SharpIconOverlayHandler/SharpIconOverlayHandler.cs
@@ -3,7 +3,6 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 using System.Security.AccessControl;
 using System.Text;
 using Microsoft.Win32;
@@ -156,7 +155,7 @@ namespace SharpShell.SharpIconOverlayHandler
         /// <returns>The icon file path.</returns>
         private string GetIconFilePath()
         {
-            //  If we're not in debug mode and we've already created the temporary icon file, 
+            //  If we're not in debug mode and we've already created the temporary icon file,
             //  we can return it. If we're in debug mode, we'll always create it.
 #if !DEBUG
             if(!string.IsNullOrEmpty(temporaryIconOverlayFilePath) && File.Exists(temporaryIconOverlayFilePath))
@@ -223,7 +222,7 @@ namespace SharpShell.SharpIconOverlayHandler
             {
                 //  Open the ShellIconOverlayIdentifiers.
                 using(var overlayIdentifiers = localMachineBaseKey
-                    .OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Explorer\ShellIconOverlayIdentifiers", 
+                    .OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Explorer\ShellIconOverlayIdentifiers",
                     RegistryKeyPermissionCheck.ReadWriteSubTree, RegistryRights.EnumerateSubKeys | RegistryRights.QueryValues | RegistryRights.CreateSubKey | RegistryRights.CreateSubKey))
                 {
                     //  If we don't have the key, we've got a problem.
@@ -238,7 +237,8 @@ namespace SharpShell.SharpIconOverlayHandler
                                                   "being registered, it will not be used by Windows Explorer.");
 
                     //  Create the overlay key.
-                    using(var overlayKey = overlayIdentifiers.CreateSubKey(serverType.Name))
+                    var keyName = RegistrationNameAttribute.GetRegistrationNameOrTypeName(serverType);
+                    using (var overlayKey = overlayIdentifiers.CreateSubKey(keyName))
                     {
                         //  If we don't have the overlay key, we've got a problem.
                         if(overlayKey == null)
@@ -274,8 +274,9 @@ namespace SharpShell.SharpIconOverlayHandler
                         throw new InvalidOperationException("Cannot open the ShellIconOverlayIdentifiers key.");
 
                     //  Delete the overlay key.
-                    if (overlayIdentifiers.GetSubKeyNames().Any(skn => skn == serverType.Name))
-                        overlayIdentifiers.DeleteSubKey(serverType.Name);
+                    var keyName = RegistrationNameAttribute.GetRegistrationNameOrTypeName(serverType);
+                    if (overlayIdentifiers.GetSubKeyNames().Any(skn => skn == keyName))
+                        overlayIdentifiers.DeleteSubKey(keyName);
                 }
             }
         }
@@ -304,7 +305,7 @@ namespace SharpShell.SharpIconOverlayHandler
         protected abstract int GetPriority();
 
         /// <summary>
-        /// Determines whether an overlay should be shown for the shell item with the path 'path' and 
+        /// Determines whether an overlay should be shown for the shell item with the path 'path' and
         /// the shell attributes 'attributes'.
         /// </summary>
         /// <param name="path">The path for the shell item. This is not necessarily the path

--- a/SharpShell/SharpShell/SharpShell.csproj
+++ b/SharpShell/SharpShell/SharpShell.csproj
@@ -69,6 +69,7 @@
       <Link>SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Attributes\AssociationType.cs" />
+    <Compile Include="Attributes\RegistrationNameAttribute.cs" />
     <Compile Include="Attributes\COMServerAssociationAttribute.cs" />
     <Compile Include="Attributes\CustomUnregisterFunctionAttribute.cs" />
     <Compile Include="Attributes\CustomRegisterFunctionAttribute.cs" />

--- a/SharpShell/SharpShell/SharpShellServer.cs
+++ b/SharpShell/SharpShell/SharpShellServer.cs
@@ -14,7 +14,7 @@ namespace SharpShell
     /// identity information (as required by ISharpShellServer), MEF contract inheritance
     /// and definitions of virtual functions that can be overriden by advanced users
     /// to hook into key points in Server Lifecycle.
-    /// 
+    ///
     /// Note that ALL derived classes will Export ISharpShellServer - this is a useful
     /// feature as it means that the ServerManager tool (and other tools) can interrogate
     /// assemblies via MEF to get information on servers they contain.
@@ -74,7 +74,7 @@ namespace SharpShell
             if (assocationAttributes.Any())
             {
                 ServerRegistrationManager.RegisterServerAssociations(
-                    type.GUID, serverType, type.Name, assocationAttributes, registrationType);
+                    type.GUID, serverType, RegistrationNameAttribute.GetRegistrationNameOrTypeName(type), assocationAttributes, registrationType);
             }
 
             //  Execute the custom register function, if there is one.
@@ -96,18 +96,18 @@ namespace SharpShell
 
             //  Get the server type.
             var serverType = ServerTypeAttribute.GetServerType(type);
-            
+
             //  Unregister the server associations, if there are any.
             if (assocationAttributes.Any())
             {
                 ServerRegistrationManager.UnregisterServerAssociations(
-                    type.GUID, serverType, type.Name, assocationAttributes, registrationType);
+                    type.GUID, serverType, RegistrationNameAttribute.GetRegistrationNameOrTypeName(type), assocationAttributes, registrationType);
             }
 
             //  Execute the custom unregister function, if there is one.
             CustomUnregisterFunctionAttribute.ExecuteIfExists(type, registrationType);
         }
-        
+
         /// <summary>
         /// Logs the specified message to the SharpShell log, with the name of the type.
         /// </summary>
@@ -139,7 +139,7 @@ namespace SharpShell
         /// </value>
         public string DisplayName
         {
-            get 
+            get
             {
                 //  Return the display name if set, otherwise the type name.
                 return DisplayNameAttribute.GetDisplayNameOrTypeName(GetType());


### PR DESCRIPTION
Because Microsoft refuses to fix its absurd icon overlay limitation, there is an arms race
under ShellIconOverlayIdentifiers for which handler appears first in the registry.
Currently SharpShell has no armament because it uses the type name for the key name,
where other tools can begin their key names with spaces so that they appear first.
This is especially difficult with Windows 10 which comes installed with 8 overlays
with key names beginning with a space, and it doesn't allow you to delete them.
This change allows specifying the registry key name to use for overlays, and while we're
at it, menu handlers and and other servers which use the type name as a registry key.
