### PR TITLE
Add DesktopBackground and DirectoryBackground AssociationType for ContextMenu

### DIFF
--- a/SharpShell/SharpShell/Attributes/AssociationType.cs
+++ b/SharpShell/SharpShell/Attributes/AssociationType.cs
@@ -37,6 +37,16 @@
         Directory,
 
         /// <summary>
+        /// Create an association to the background of folders and the desktop
+        /// </summary>
+        DirectoryBackground,
+
+        /// <summary>
+        /// Create an association to the background of the desktop (Windows 7 and higher)
+        /// </summary>
+        DesktopBackground,
+        
+        /// <summary>
         /// Create an association to the drive class.
         /// </summary>
         Drive,

--- a/SharpShell/SharpShell/ServerRegistration/ServerRegistrationManager.cs
+++ b/SharpShell/SharpShell/ServerRegistration/ServerRegistrationManager.cs
@@ -599,6 +599,16 @@ namespace SharpShell.ServerRegistration
                     //  Return the directory class.
                     return new[] { SpecialClass_Directory };
 
+                case AssociationType.DirectoryBackground:
+
+                    //  Return the directory background class.
+                    return new[] { SpecialClass_DirectoryBackground };
+
+                case AssociationType.DesktopBackground:
+
+                    //  Return the desktop background class.
+                    return new[] {SpecialClass_DesktopBackground};
+
                 case AssociationType.Drive:
 
                     //  Return the directory class.
@@ -865,6 +875,16 @@ namespace SharpShell.ServerRegistration
         /// The 'directory' special class.
         /// </summary>
         private const string SpecialClass_Directory = @"Directory";
+
+        /// <summary>
+        /// The 'directory background' special class.
+        /// </summary>
+        private const string SpecialClass_DirectoryBackground = @"Directory\Background";
+
+        /// <summary>
+        /// The 'desktop background' special class.
+        /// </summary>
+        private const string SpecialClass_DesktopBackground = @"DesktopBackground";
 
         /// <summary>
         /// The 'unknown files' special class.


### PR DESCRIPTION
Adding some missing association types.
 [https://msdn.microsoft.com/en-us/library/windows/desktop/cc144110(v=vs.85).aspx](https://msdn.microsoft.com/en-us/library/windows/desktop/cc144110(v=vs.85).aspx)
Rightclicking on background of folder, and desktop background