### PR TITLE
fix(thumbnail-handler): fix bug where file was locked

### DIFF
--- a/SharpShell/SharedAssemblyInfo.cs
+++ b/SharpShell/SharedAssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 //  Shared Assembly Information for all projects in SharpShell.
 [assembly: AssemblyCompany("Dave Kerr")]
 [assembly: AssemblyProduct("SharpShell")]
-[assembly: AssemblyCopyright("Copyright © Dave Kerr 2014")]
+[assembly: AssemblyCopyright("Copyright © Dave Kerr 2018")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.2.1.0")]
+[assembly: AssemblyFileVersion("2.2.1.0")]

--- a/SharpShell/SharpShell/Helpers/ComStream.cs
+++ b/SharpShell/SharpShell/Helpers/ComStream.cs
@@ -30,6 +30,18 @@ namespace SharpShell.Helpers
         {
             Marshal.FreeCoTaskMem(bufferPointer);
         }
+        /// <summary>
+        /// Releases all resources used by the Com Stream.
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected override void Dispose(bool disposing)
+        {
+            //  Release the underlying stream.
+            if (comStream != null)
+            {
+                Marshal.ReleaseComObject(comStream);
+            }
+        }
 
         /// <summary>
         /// When overridden in a derived class, clears all buffers for this stream and causes 

--- a/SharpShell/SharpShellNativeBridge/SharpShellNativeBridge.vcxproj
+++ b/SharpShell/SharpShellNativeBridge/SharpShellNativeBridge.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -36,27 +36,27 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/Tests/TestData/ThumbnailHandlers/Sample Text.txt
+++ b/Tests/TestData/ThumbnailHandlers/Sample Text.txt
@@ -1,0 +1,1 @@
+Sample Text Here


### PR DESCRIPTION
Generating the thumbnail for a file locked the file as SharpShell
was keeping a handle on the underlying file stream. This has now
been resolved, fixes #78