### PR TITLE
Make PreviewHandlerHost instead of PreviewHandlerControl inherit from…

### DIFF
--- a/SharpShell/SharpShell/SharpPreviewHandler/PreviewHandlerControl.cs
+++ b/SharpShell/SharpShell/SharpPreviewHandler/PreviewHandlerControl.cs
@@ -6,16 +6,8 @@ namespace SharpShell.SharpPreviewHandler
     /// <summary>
     /// Base class for preview handler controls.
     /// </summary>
-    public class PreviewHandlerControl : Form
+    public class PreviewHandlerControl : UserControl
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PreviewHandlerControl"/> class.
-        /// </summary>
-        protected PreviewHandlerControl()
-        {
-            FormBorderStyle = FormBorderStyle.None;
-        }
-
         /// <summary>
         /// Sets the color of the background, if possible, to coordinate with the windows
         /// color scheme.

--- a/SharpShell/SharpShell/SharpPreviewHandler/PreviewHandlerHost.cs
+++ b/SharpShell/SharpShell/SharpPreviewHandler/PreviewHandlerHost.cs
@@ -13,7 +13,7 @@ namespace SharpShell.SharpPreviewHandler
     /// The PreviewHandlerHost is the window created in the preview 
     /// pane which will hold the derived preview handlers UI.
     /// </summary>
-    internal class PreviewHandlerHost : UserControl
+    internal class PreviewHandlerHost : Form
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PreviewHandlerHost"/> class.
@@ -22,6 +22,8 @@ namespace SharpShell.SharpPreviewHandler
         {
             //  Initialize the component.
             InitializeComponent();
+
+            FormBorderStyle = FormBorderStyle.None;
 
             //  Invisible by default.
             Visible = false;


### PR DESCRIPTION
… Form

Related to https://github.com/dwmkerr/sharpshell/pull/169

1) Since PreviewHandlerHost is internal make that inherit from Form instead.
2) Looks like having PreviewHandlerControl inherit from Form creates a problem if someone wants to use User32.GetParent(Handle) in a class that inherits from PreviewHandlerControl, as it returns zero.
