### PR TITLE
Update host on SetWindow call

### DIFF
--- a/SharpShell/SharpShell/SharpPreviewHandler/SharpPreviewHandler.cs
+++ b/SharpShell/SharpShell/SharpPreviewHandler/SharpPreviewHandler.cs
@@ -251,6 +251,9 @@ namespace SharpShell.SharpPreviewHandler
             previewArea = prc;
             previewHostHandle = hwnd;
 
+            //  Update host.
+            UpdateHost();
+
             //  Return success.
             return WinError.S_OK;
         }
@@ -294,7 +297,7 @@ namespace SharpShell.SharpPreviewHandler
                 //  Call the base.
                 OnPreviewHostThread(() => { previewHandlerControl = DoPreview(); });
 
-                //  Update bounds.
+                //  Update host.
                 UpdateHost();
             }
             catch (Exception exception)
@@ -327,7 +330,11 @@ namespace SharpShell.SharpPreviewHandler
                     OnPreviewHostThread(
                         () =>
                             {
-                                if (previewHandlerControl != null) previewHandlerControl.Dispose();
+                                if (previewHandlerControl != null)
+                                {
+                                    previewHandlerControl.Dispose();
+                                    previewHandlerControl = null;
+                                }
                             });
                     
                 }


### PR DESCRIPTION
Hi,

First of all - thanks for your work! Initially, I developed my PreviewHandler in C++, but thankfully I found your library and managed to get my extension working way faster.

But, unfortunately, I came across the following issue: PreviewHandler's control will only be properly resized on the second selection i.e I have to select some other item in Explorer and select back the original item to get my form resized.

After digging I found out that current [SetWindow](https://github.com/dwmkerr/sharpshell/blob/master/SharpShell/SharpShell/SharpPreviewHandler/SharpPreviewHandler.cs#L245) implementation is missing two things:

1. Geometry update as per [MSDN](https://docs.microsoft.com/en-us/windows/desktop/shell/building-preview-handlers#ipreviewhandlersetwindow)
2. And most importantly - setting the parent to our host control

Also, we should set reference to `null` after we disposed it, else it becomes dangling and leads to crash in `UpdateHost` method if it's called from `SetWindow`

Thanks,
Vasily.