### PR TITLE
feat: add the RegAsm helper to SharpShell

### DIFF
--- a/SharpShell/SharpShell/Diagnostics/Loggers/FileLogger.cs
+++ b/SharpShell/SharpShell/Diagnostics/Loggers/FileLogger.cs
@@ -43,7 +43,7 @@ namespace SharpShell.Diagnostics.Loggers
 
                 //  Write to the line to the file.
                 using (var w = File.AppendText(logPath))
-                    w.WriteLine(line);
+                    w.WriteLine($"{DateTime.Now.ToString(@"yyyy-MM-dd HH:mm:ss.fffZ")} - {Process.GetCurrentProcess().ProcessName } - {line}");
             }
             catch (Exception exception)
             {
@@ -62,7 +62,7 @@ namespace SharpShell.Diagnostics.Loggers
         /// <param name="error">The error.</param>
         public void LogError(string error)
         {
-            Write("Error: " + error);
+            Write("error: " + error);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace SharpShell.Diagnostics.Loggers
         /// <param name="warning">The warning.</param>
         public void LogWarning(string warning)
         {
-            Write("Warning: " + warning);
+            Write("warning: " + warning);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace SharpShell.Diagnostics.Loggers
         /// <param name="message">The message.</param>
         public void LogMessage(string message)
         {
-            Write("Message: " + message);
+            Write(message);
         }
     }
 }

--- a/SharpShell/SharpShell/Helpers/RegAsm.cs
+++ b/SharpShell/SharpShell/Helpers/RegAsm.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using SharpShell.Diagnostics;
+
+namespace SharpShell.Helpers
+{
+    /// <summary>
+    /// RegAsm provides a simple interface to find and run a locally installed 'regasm.exe' executable.
+    /// </summary>
+    public class RegAsm
+    {
+        /// <summary>
+        /// The standard output from the most recent execution.
+        /// </summary>
+        public string StandardOutput { get; private set; }
+
+        /// <summary>
+        /// The standard error from the most recent execution.
+        /// </summary>
+        public string StandardError { get; private set; }
+
+        /// <summary>
+        /// Registers the given assembly, as 32 bit.
+        /// </summary>
+        /// <param name="assemblyPath">The assembly path.</param>
+        /// <param name="codebase">if set to <c>true</c> set the codebase flag.</param>
+        /// <returns><c>true</c> if registration succeeded, <c>false</c> otherwise.</returns>
+        public bool Register32(string assemblyPath, bool codebase)
+        {
+            var flags = codebase ? "/codebase" : string.Empty;
+            var args = $@"{flags} ""{assemblyPath}""";
+            return Execute(FindRegAsmPath32(), args);
+        }
+
+        /// <summary>
+        /// Registers the given assembly, as 64 bit.
+        /// </summary>
+        /// <param name="assemblyPath">The assembly path.</param>
+        /// <param name="codebase">if set to <c>true</c> set the codebase flag.</param>
+        /// <returns><c>true</c> if registration succeeded, <c>false</c> otherwise.</returns>
+        public bool Register64(string assemblyPath, bool codebase)
+        {
+            var flags = codebase ? "/codebase" : string.Empty;
+            var args = $"{flags} \"{assemblyPath}\"";
+            return Execute(FindRegAsmPath64(), args);
+        }
+
+        /// <summary>
+        /// Unregisters the given assembly, as 32 bit.
+        /// </summary>
+        /// <param name="assemblyPath">The assembly path.</param>
+        /// <returns><c>true</c> if unregistration succeeded, <c>false</c> otherwise.</returns>
+        public bool Unregister32(string assemblyPath)
+        {
+            var args = $"/u \"{assemblyPath}\"";
+            return Execute(FindRegAsmPath32(), args);
+        }
+
+        /// <summary>
+        /// Unregisters the given assembly, as 64 bit.
+        /// </summary>
+        /// <param name="assemblyPath">The assembly path.</param>
+        /// <returns><c>true</c> if unregistration succeeded, <c>false</c> otherwise.</returns>
+        public bool Unregister64(string assemblyPath)
+        {
+            var args = $"/u \"{assemblyPath}\"";
+            return Execute(FindRegAsmPath64(), args);
+        }
+
+        private bool Execute(string regasmPath, string arguments)
+        {
+            var regasm = new Process
+            {
+                StartInfo =
+                {
+                    FileName = regasmPath,
+                    Arguments = arguments,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                }
+            };
+
+            Logging.Log($@"RegAsm: preparing to run {regasmPath} {arguments}");
+            regasm.Start();
+            regasm.WaitForExit();
+            StandardOutput = regasm.StandardOutput.ReadToEnd();
+            StandardError = regasm.StandardError.ReadToEnd();
+            Logging.Log($@"RegAsm: exited with code {regasm.ExitCode}");
+            return regasm.ExitCode == 0;
+        }
+
+        private static string FindRegAsmPath32()
+        {
+            return FindRegAsmPath("Framework");
+        }
+
+        private static string FindRegAsmPath64()
+        {
+            return FindRegAsmPath("Framework64");
+        }
+
+        /// <summary>
+        /// Finds the 'regasm.exe' path, from the given framework folder.
+        /// </summary>
+        /// <param name="frameworkFolder">The framework folder, which would normally be <code>%WINDIR%\Microsoft.NET\Framework</code> or
+        /// <code>%WINDIR%\Microsoft.NET\Framework64</code>.</param>
+        /// <returns>The path to the regasm.exe executable, from the most recent .NET Framework installation.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if a valid regasm path cannot be found.</exception>
+        private static string FindRegAsmPath(string frameworkFolder)
+        {
+            //  This function essentially will set for folders inside the 'Framework' folder, then
+            //  build a path to a hypothetical 'regasm.exe' in the folder:
+            //
+            //  C:\WINDOWS\Microsoft.Net\Framework\v1.0.3705\regasm.exe
+            //  C:\WINDOWS\Microsoft.Net\Framework\v1.1.4322\regasm.exe
+            //  C:\WINDOWS\Microsoft.Net\Framework\v2.0.50727\regasm.exe
+            //  C:\WINDOWS\Microsoft.Net\Framework\v4.0.30319\regasm.exe
+            //
+            //  It will then sort descending, and pick the first regasm which actually exists, or return null.
+
+            //  Build an array of candidate paths - these are paths which *might* point to a valid regasm executable.
+            var searchRoot = Path.Combine(Environment.ExpandEnvironmentVariables("%WINDIR%"), @"Microsoft.Net", frameworkFolder);
+            var frameworkDirectories = Directory.GetDirectories(searchRoot, "v*", SearchOption.TopDirectoryOnly);
+            var candidates = frameworkDirectories.Select(c => Path.Combine(c, @"regasm.exe")).ToArray();
+
+            //  Sort descending, i.e. we're shooting for the latest framework available.
+            var sorted = candidates.OrderByDescending(s => s);
+
+            //  Return the first element which exists, or null.
+            var path = sorted.Where(File.Exists).FirstOrDefault();
+
+            //  If we failed to find the path, boot an exception.
+            if (path == null)
+            {
+                throw new InvalidOperationException($"Failed to find regasm in '{searchRoot}'. Checked: {Environment.NewLine + string.Join(Environment.NewLine, candidates)}");
+            }
+
+            return path;
+        }
+    }
+}

--- a/SharpShell/SharpShell/SharpShell.csproj
+++ b/SharpShell/SharpShell/SharpShell.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Extensions\GuidExtensions.cs" />
     <Compile Include="Extensions\IDataObjectExtensions.cs" />
     <Compile Include="Helpers\ComStream.cs" />
+    <Compile Include="Helpers\RegAsm.cs" />
     <Compile Include="Helpers\Win32Helper.cs" />
     <Compile Include="InitializeWithStreamServer.cs" />
     <Compile Include="Interop\ASSOCCLASS.cs" />

--- a/SharpShell/SharpShell/SharpShellServer.cs
+++ b/SharpShell/SharpShell/SharpShellServer.cs
@@ -64,6 +64,8 @@ namespace SharpShell
         /// <param name="registrationType">Type of the registration.</param>
         internal static void DoRegister(Type type, RegistrationType registrationType)
         {
+            Logging.Log($"Preparing to register SharpShell Server {type.Name} as {registrationType}");
+
             //  Get the assoication data.
             var assocationAttributes = type.GetCustomAttributes(typeof(COMServerAssociationAttribute), true)
                 .OfType<COMServerAssociationAttribute>().ToList();
@@ -83,6 +85,7 @@ namespace SharpShell
 
             //  Notify the shell we've updated associations.
             Shell32.SHChangeNotify(Shell32.SHCNE_ASSOCCHANGED, 0, IntPtr.Zero, IntPtr.Zero);
+            Logging.Log($"Registration of {type.Name} completed");
         }
 
         /// <summary>
@@ -94,6 +97,8 @@ namespace SharpShell
         /// <param name="registrationType">Type of the registration to unregister.</param>
         internal static void DoUnregister(Type type, RegistrationType registrationType)
         {
+            Logging.Log($"Preparing to unregister SharpShell Server {type.Name} as {registrationType}");
+
             //  Get the assoication data.
             var assocationAttributes = type.GetCustomAttributes(typeof(COMServerAssociationAttribute), true)
                 .OfType<COMServerAssociationAttribute>().ToList();
@@ -113,6 +118,7 @@ namespace SharpShell
 
             //  Notify the shell we've updated associations.
             Shell32.SHChangeNotify(Shell32.SHCNE_ASSOCCHANGED, 0, IntPtr.Zero, IntPtr.Zero);
+            Logging.Log($"Unregistration of {type.Name} completed");
         }
         
         /// <summary>

--- a/docs/logging/logging.md
+++ b/docs/logging/logging.md
@@ -41,6 +41,8 @@ For example, the screenshot below shows the [`DebugView`](https://docs.microsoft
 
 Debug output is highly performant, and should probably be considered to be the safest way to monitor logs from SharpShell servers.
 
+Note: If you already have a trace listener running, such as the debugger in Visual Studio, it will likely capture the trace output and show it before DebugView can.
+
 ## Windows Event Log Output
 
 With this option enabled, SharpShell will write all log messages to an Application Event Log named `SharpShell`.


### PR DESCRIPTION
This helper allows the caller to quickly install or uninstall SharpShell servers via RegAsm.
Also adds more logging to servers during registration and
unregistration, and improves the output of the file log.