### PR TITLE
fix: better exception handling if SRM embedded assembly loading fails

### DIFF
--- a/SharpShell/SharpShell/SharpThumbnailHandler/SharpThumbnailHandler.cs
+++ b/SharpShell/SharpShell/SharpThumbnailHandler/SharpThumbnailHandler.cs
@@ -29,7 +29,7 @@ namespace SharpShell.SharpThumbnailHandler
         int IThumbnailProvider.GetThumbnail(uint cx, out IntPtr phbmp, out WTS_ALPHATYPE pdwAlpha)
         {
             //  DebugLog this key event.
-            Log(string.Format("GetThumbnail for item stream, width {0}.", cx));
+            Log($"GetThumbnail for item stream, width {cx}.");
 
             //  Set the out variables to default values.
             phbmp = IntPtr.Zero;

--- a/SharpShell/Tools/ServerRegistrationManager/Program.cs
+++ b/SharpShell/Tools/ServerRegistrationManager/Program.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using ServerRegistrationManager.OutputService;
 
 namespace ServerRegistrationManager
@@ -41,6 +37,12 @@ namespace ServerRegistrationManager
                 //  Load the resource.
                 using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
                 {
+                    //  If we cannot load the resource, the best we can do at this stage is to throw as informative exception as possible.
+                    if (stream == null)
+                    {
+                        throw new InvalidOperationException($"Unable to load embedded assembly '{assemblyName}' from '{resourceName}'");
+                    }
+
                     var assemblyData = new byte[stream.Length];
                     stream.Read(assemblyData, 0, assemblyData.Length);
                     return Assembly.Load(assemblyData);

--- a/SharpShell/coverage.ps1
+++ b/SharpShell/coverage.ps1
@@ -3,7 +3,11 @@ choco install -y --no-progress opencover.portable codecov nunit-console-runner
 
 # Create an artifacts directory and build the report.
 New-Item -ItemType Directory -Force -Path "$PSScriptRoot\artifacts\coverage"
-OpenCover.Console.exe "-target:nunit3-console.exe" "-targetargs:$PSScriptRoot\SharpShell.Tests\bin\Release\SharpShell.Tests.dll"  "-filter:+[SharpShell*]* -[SharpShell.Tests   *]*" "-register:user" "-output:$PSScriptRoot\artifacts\coverage\coverage.xml"
+OpenCover.Console.exe "-target:nunit3-console.exe" `
+    "-targetargs:$PSScriptRoot\SharpShell.Tests\bin\Release\SharpShell.Tests.dll" `
+    "-filter:+[SharpShell*]* -[SharpShell.Tests*]*" `
+    "-register:user" `
+    "-output:$PSScriptRoot\artifacts\coverage\coverage.xml"
 
 # Upload the report to codecov. The CODECOV_TOKEN env var must be set.
 codecov -f "$PSScriptRoot\artifacts\coverage\coverage.xml"


### PR DESCRIPTION
Also tidies up a couple of log messages and breaks the coverage script
into multiple lines for legibility. Fixes #120.