### PR TITLE
Workaround to avoid Explorer.exe crash after a property page "disappears".

### DIFF
--- a/SharpShell/SharpShell/SharpPropertySheet/PropertyPageProxy.cs
+++ b/SharpShell/SharpShell/SharpPropertySheet/PropertyPageProxy.cs
@@ -175,10 +175,10 @@ namespace SharpShell.SharpPropertySheet
                 Target?.Dispose();
 
             } catch (NullReferenceException ex) {
-                Logging.Log("Failed to dispose 'Target' instance due it is already disposed.");
+                Logging.Error(string.Format("Failed to dispose '{0}' because it is already disposed.", nameof(Target)));
 
             } catch (Exception ex) {
-                Logging.Log("Failed to dispose 'Target' instance due undetermined reasons.");
+                Logging.Error(string.Format("Failed to dispose '{0}' due undetermined reasons.", nameof(Target)));
                 // MessageBox.Show(ex.Message);
             }
 

--- a/SharpShell/SharpShell/SharpPropertySheet/PropertyPageProxy.cs
+++ b/SharpShell/SharpShell/SharpPropertySheet/PropertyPageProxy.cs
@@ -163,8 +163,24 @@ namespace SharpShell.SharpPropertySheet
 
         private void Cleanup()
         {
-            //  Destory the target.
-            Target.Dispose();
+            // Temporal workaround to prevent Explorer.exe from crashing after a property page "disappears".
+            // This occur in a undetermined scenario when opening multiple property pages, 
+            // which, on these circumstances, a call to 'Target.Dispose()' will throw a NullReferenceException.
+            //
+            // See related issues for more info: 
+            //  - https://github.com/dwmkerr/sharpshell/issues/177
+            //  - https://github.com/dwmkerr/sharpshell/issues/88
+            try {
+                //  Destroy the target.
+                Target?.Dispose();
+
+            } catch (NullReferenceException ex) {
+                Logging.Log("Failed to dispose 'Target' instance due it is already disposed.");
+
+            } catch (Exception ex) {
+                Logging.Log("Failed to dispose 'Target' instance due undetermined reasons.");
+                // MessageBox.Show(ex.Message);
+            }
 
             //  Destroy the host.
             User32.DestroyWindow(HostWindowHandle);


### PR DESCRIPTION
Temporal workaround to prevent Explorer.exe from crashing after a property page "disappears".
This occur in a undetermined scenario when opening multiple property pages, 
which, on these circumstances, a call to 'Target.Dispose()' will throw a NullReferenceException.

See related issues for more info: 
 - https://github.com/dwmkerr/sharpshell/issues/177
 - https://github.com/dwmkerr/sharpshell/issues/88