### PR TITLE
feat: more logging options for Property Pages, automatic property page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version X
+
+- Property Pages: Are resized automatically, which fixes some scaling issues.
+- Property Pages: Improved logging for Property Pages.
+
 ## Version 2.6.0
 
 Note that release 2.4.3 was incorrectly released as 2.5.3. This release jumps to 2.6.0 to attempt to minimise disruption.

--- a/SharpShell/SharpShell/SharpPropertySheet/SharpPropertyPage.cs
+++ b/SharpShell/SharpShell/SharpPropertySheet/SharpPropertyPage.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using SharpShell.Diagnostics;
 
 namespace SharpShell.SharpPropertySheet
 {
@@ -13,6 +14,33 @@ namespace SharpShell.SharpPropertySheet
     /// </summary>
     public class SharpPropertyPage : UserControl
     {
+        #region Logging Helper Functions
+
+        /// <summary>
+        /// Logs the specified message. Will include the Shell Extension name and page name if available.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        protected void Log(string message)
+        {
+            var parent = PropertyPageProxy?.Parent;
+            var level1 = parent != null ? parent.DisplayName : "Unknown";
+            Logging.Log($"{level1} ('{PageTitle}' Page): {message}");
+        }
+
+        /// <summary>
+        /// Logs the specified message as an error.  Will include the Shell Extension name and page name if available.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="exception">Optional exception details.</param>
+        protected void LogError(string message, Exception exception = null)
+        {
+            var parent = PropertyPageProxy?.Parent;
+            var level1 = parent != null ? parent.DisplayName : "Unknown";
+            Logging.Error($"{level1} ('{PageTitle}' Page): {message}", exception);
+        }
+
+        #endregion
+
         /// <summary>
         /// Gets or sets the page title.
         /// </summary>
@@ -32,7 +60,7 @@ namespace SharpShell.SharpPropertySheet
         /// <param name="parent">The parent property sheet.</param>
         protected internal virtual void OnPropertyPageInitialised(SharpPropertySheet parent)
         {
-            
+            Log("Page initialised");
         }
 
         /// <summary>
@@ -40,7 +68,7 @@ namespace SharpShell.SharpPropertySheet
         /// </summary>
         protected internal virtual void OnPropertyPageSetActive()
         {
-
+            Log("Page activated");
         }
 
         /// <summary>
@@ -48,7 +76,7 @@ namespace SharpShell.SharpPropertySheet
         /// </summary>
         protected internal virtual void OnPropertyPageKillActive()
         {
-
+            Log("Page deactivated");
         }
 
         /// <summary>
@@ -57,7 +85,7 @@ namespace SharpShell.SharpPropertySheet
         /// </summary>
         protected internal virtual void OnPropertySheetApply()
         {
-            
+            Log("Page apply");
         }
 
         /// <summary>
@@ -65,7 +93,7 @@ namespace SharpShell.SharpPropertySheet
         /// </summary>
         protected internal virtual void OnPropertySheetOK()
         {
-            
+            Log("Page OK");
         }
 
         /// <summary>
@@ -73,7 +101,7 @@ namespace SharpShell.SharpPropertySheet
         /// </summary>
         protected internal virtual void OnPropertySheetCancel()
         {
-            
+            Log("Page cancel");
         }
 
         /// <summary>
@@ -81,7 +109,7 @@ namespace SharpShell.SharpPropertySheet
         /// </summary>
         protected internal virtual void OnPropertySheetClose()
         {
-
+            Log("Page close");
         }
 
         /// <summary>

--- a/docs/logging/logging.md
+++ b/docs/logging/logging.md
@@ -65,10 +65,24 @@ Note: If the extension host does not have permissions to access the file, this c
 
 Logging Configuration is loaded via the `SystemConfigurationProvider` class. Logging functionality is provided via the `Logging` class.
 
-All classes which dervive from `SharpShellServer` can use the following fuctions to write to the log, automatically including the extension name:
+You can call logging methods explicitly, as below:
 
-- `Log`
-- `LogError`
+```csharp
+Logging.Log("Message from SharpShell");
+Logging.Error("Uh-oh", new Exception());
+```
+
+Some classes have helper functions which allow write to the log, but provide the Server Name or other useful information. Always check for a 
+`Log` or `LogError` method before using the generic methods above. The following functions are available:
+
+| Function                     | Notes                                                                                           |
+|------------------------------|-------------------------------------------------------------------------------------------------|
+| `SharpShellServer.Log`       | Logs a message, automatically including the server display name.                                |
+| `SharpShellServer.LogError`  | Logs an error, automatically including the server display name.                                 |
+| `SharpPropertyPage.Log`      | Logs a message, automatically including the server display name and property page display name. |
+| `SharpPropertyPage.LogError` | Logs an error, automatically including the server display name and property page display name.  |
+
+When available, the functions above (or equivalents) should be preferred as they will add more context to the log messages.
 
 ## Appendix: Why Not log4net?
 


### PR DESCRIPTION
sizing

This commit adds more logging for Property Page extensions. It also
ensures that the size of a SharpPropertySheet is set automatically. This
makes it easier to build a page which has any size in the designer, then
anchor controls to the appropriate location, knowing that the control
will be sized appropriately when shown to the user.

Here's an example of log output:

```
2018-10-31 13:09:45.069Z - explorer - ResourcesView of \\Mac\Home\repos\github\dwmkerr\sharpshell\SharpShell\Tools\ServerManager\bin\Debug\Apex.WinForms.dll: Add Ref 0 -> 1
2018-10-31 13:09:45.075Z - explorer - ResourcesPropertySheet: Created Page Proxy, handle is 05232b10
2018-10-31 13:09:45.081Z - explorer - ResourcesPropertySheet: Adding Pages (Done)
2018-10-31 13:09:46.280Z - explorer - ResourcesView of \\Mac\Home\repos\github\dwmkerr\sharpshell\SharpShell\Tools\ServerManager\bin\Debug\Apex.WinForms.dll: Create
2018-10-31 13:09:46.293Z - explorer - ResourcesPropertySheet (Proxy for Resources): Got WM_SIZE
2018-10-31 13:09:46.300Z - explorer - ResourcesPropertySheet (Proxy for Resources): Got WM_SIZE (681x816)
2018-10-31 13:09:46.309Z - explorer - ResourcesPropertySheet (Resources): Page activated
```

Note that we see info from the 'proxy' property page, as well as the page itself. This makes it easier to see _which_ pages messages are coming from. This is critical when diagnosing issues with multiple pages (i.e. for #177).

Here's an example of the sizing. In the designer, we have a small page. At runtime, it has been resized to match the exact bounds for the property sheet:

![image](https://user-images.githubusercontent.com/1926984/47766135-8a0b1f00-dd10-11e8-94c9-1b3976c6123c.png)
