### PR TITLE
fix: fix property page background paint issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Version X
 
+- Property Pages: Fix issue with incorrect background colour and controls which disappear.
 - Property Pages: Are resized automatically, which fixes some scaling issues.
 - Property Pages: Improved logging for Property Pages.
 - Native Bridge: Improved Native Bridge logging.

--- a/SharpShell/SharpShell/SharpPropertySheet/PropertyPageProxy.cs
+++ b/SharpShell/SharpShell/SharpPropertySheet/PropertyPageProxy.cs
@@ -30,7 +30,7 @@ namespace SharpShell.SharpPropertySheet
         {
             var level1 = Parent != null ? Parent.DisplayName : "Unknown";
             var level2 = Target != null ? Target.PageTitle : "Unknown";
-            Logging.Log($"{level1} (Proxy for '{level2}' Page): {message}");
+            Logging.Log($"{level1} (Proxy {HostWindowHandle.ToString("x8")} for '{level2}' Page): {message}");
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace SharpShell.SharpPropertySheet
         {
             var level1 = Parent != null ? Parent.DisplayName : "Unknown";
             var level2 = Target != null ? Target.PageTitle : "Unknown";
-            Logging.Error($"{level1} (Proxy for {level2}): {message}", exception);
+            Logging.Error($"{level1} (Proxy {HostWindowHandle.ToString("x8")} for {level2}): {message}", exception);
         }
 
         #endregion
@@ -91,6 +91,13 @@ namespace SharpShell.SharpPropertySheet
                     Target?.SetBounds(0, 0, width, height);
 
                     break;
+
+                //  The proxy window is really just a container for the user control which holds the user defined
+                //  property sheet content. So make it transparent (otherwise we'll get a grey dialog background).
+                case WindowsMessages.WM_ERASEBKGND:
+                    
+                    //  Return true - i.e. we handled erasing the background (by doing nothing).
+                    return new IntPtr(1);
 
                 case WindowsMessages.WM_INITDIALOG:
                     


### PR DESCRIPTION
I noticed a few rendering issues with the property sheet. The proxy window which hosts the property pages was not transparent. This meant that:

1. SharpPropertySheet extension property pages would have an invalid background colour
2. If the paint order wasn't as we'd expect, the background would sometimes paint over the foreground, making it appear as if the controls have disappeared

Both examples are shown below:

![image](https://user-images.githubusercontent.com/1926984/47775635-8a68e180-dd33-11e8-8681-744e8854e564.png)

For the disappearing controls, just forcing a redraw (for example, by dragging the window off the screen and back onto it) caused the controls to appear again, so I _don't_ think this fixes #177. However, it is still a nasty bug and made trying to diagnose #177 much harder.

This PR fixes the issue, which should make it easier to continue fixing #177.