### PR TITLE
fix: fixed incorrect error handling for bridge loading

### DIFF
--- a/SharpShell/SharpShell/NativeBridge/NativeBridge.cs
+++ b/SharpShell/SharpShell/NativeBridge/NativeBridge.cs
@@ -78,6 +78,7 @@ namespace SharpShell.NativeBridge
             {
                 //  Log the exception.
                 LogError("Exception during loading of the bridge library", exception);
+                return false;
             }
 
             //  If the library hasn't been loaded, log the last windows error.


### PR DESCRIPTION
This PR fixes a bug which meant that in certain circumstances if the bridge library failed to load, we would not fail the call and attempt to continue, putting the extension in an undefined state.