### PR TITLE
fix: property page cleanup lifecycle fix

### DIFF
--- a/SharpShell/SharpShell/SharpPropertySheet/SharpPropertyPage.cs
+++ b/SharpShell/SharpShell/SharpPropertySheet/SharpPropertyPage.cs
@@ -113,6 +113,15 @@ namespace SharpShell.SharpPropertySheet
         }
 
         /// <summary>
+        /// Called when the property page is being released. Use this to clean up managed and unmanaged resources.
+        /// Do *not* use it to close window handles - the window will be closed automatically as the sheet closes.
+        /// </summary>
+        protected internal virtual void OnRelease()
+        {
+            Log("Page Release");
+        }
+
+        /// <summary>
         /// Sets the page data changed.
         /// </summary>
         /// <param name="changed">if set to <c>true</c> the data has changed and the property sheet should enable the 'Apply' button.</param>

--- a/SharpShell/SharpShell/SharpPropertySheet/SharpPropertySheet.cs
+++ b/SharpShell/SharpShell/SharpPropertySheet/SharpPropertySheet.cs
@@ -73,6 +73,8 @@ namespace SharpShell.SharpPropertySheet
                 Log("Created Page Proxy, handle is " + propertyPageHandle.ToString("x8"));
 
                 //  Now that we have the page handle, add the page via the callback.
+                //  Note that if the call fails, we *don't* have to destroy the property
+                //  page handle, the bridge actually takes care of that for us.
                 bridge.CallAddPropSheetPage(pfnAddPage, propertyPageHandle, lParam);
             }
 


### PR DESCRIPTION
This fix resolves an issue where we attempted to destroy the property
page windows as the sheet is released. This is in fact not necessary as
the shell does it, and attempting to do it can cause serious runtime
issues.

Note: I can explicitly confirm that we do _not_ need to destroy the page ourselves. Here's my log output:

```
2018-11-01 12:14:39.404Z - explorer - ResourcesPropertySheet: Adding Pages...
2018-11-01 12:14:39.412Z - explorer - NativeBridge: Preparing to load 'SharpShell.NativeBridge.SharpShellNativeBridge64.dll' into 'C:\Users\dave\AppData\Local\Temp\ad5be6e9-810b-4dd9-b0b9-f3bcf1e0f5d2.dll'...
2018-11-01 12:14:39.466Z - explorer - NativeBridge: Loaded bridge successfully
2018-11-01 12:14:39.494Z - explorer - ResourcesPropertySheet (Proxy 00000000 for 'Resources' Page): Creating property page handle via bridge.
2018-11-01 12:14:39.522Z - explorer - ResourcesPropertySheet (Proxy 00000000 for 'Resources' Page): Add Ref 0 -> 1
2018-11-01 12:14:39.535Z - explorer - ResourcesPropertySheet: Created Page Proxy, handle is 0e333170
2018-11-01 12:14:39.551Z - explorer - ResourcesPropertySheet: Adding Pages (Done)
2018-11-01 12:14:43.132Z - explorer - ResourcesPropertySheet (Proxy 0e333170 for 'Resources' Page): Create Callback
2018-11-01 12:14:43.153Z - explorer - ResourcesPropertySheet ('Resources' Page): Page activated
2018-11-01 12:14:46.000Z - explorer - ResourcesPropertySheet ('Resources' Page): Page deactivated
2018-11-01 12:14:46.350Z - explorer - ResourcesPropertySheet ('Resources' Page): Page activated
2018-11-01 12:14:47.057Z - explorer - ResourcesPropertySheet ('Resources' Page): Page deactivated
2018-11-01 12:14:47.431Z - explorer - ResourcesPropertySheet ('Resources' Page): Page activated
2018-11-01 12:14:48.405Z - explorer - ResourcesPropertySheet ('Resources' Page): Page deactivated
2018-11-01 12:14:48.420Z - explorer - ResourcesPropertySheet ('Resources' Page): Page OK
2018-11-01 12:14:48.439Z - explorer - ResourcesPropertySheet (Proxy 0e333170 for 'Resources' Page): Proxy is being destroyed...
2018-11-01 12:14:48.456Z - explorer - ResourcesPropertySheet (Proxy 0e333170 for 'Resources' Page): Release Ref 1 -> 0
2018-11-01 12:14:48.464Z - explorer - ResourcesPropertySheet ('Resources' Page): Page Release
```

As indicated by the line `Proxy is being destroyed...` we can confirm the shell itself is ensuring the `WM_DESTROY` message is sent, which will destroy the proxy and its children (including the user created `SharpPropertyPage`.

This *may* solve some of the issues relating to #222, but there is still one more fix pending.