### PR TITLE
refactor: remove IRegistry properties

### DIFF
--- a/SharpShell/SharpShell/Diagnostics/ExplorerConfigurationManager.cs
+++ b/SharpShell/SharpShell/Diagnostics/ExplorerConfigurationManager.cs
@@ -27,7 +27,8 @@ namespace SharpShell.Diagnostics
             //  Get the registry service.
             var registry = ServiceRegistry.ServiceRegistry.GetService<IRegistry>();
 
-            using (var alwaysUnloadDLLKey = registry.LocalMachine.OpenSubKey(KeyName_AlwaysUnloadDll))
+            using (var localMachine = registry.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default))
+            using (var alwaysUnloadDLLKey = localMachine.OpenSubKey(KeyName_AlwaysUnloadDll))
             {
                 return alwaysUnloadDLLKey != null;
             }   
@@ -42,7 +43,8 @@ namespace SharpShell.Diagnostics
             //  Get the registry service.
             var registry = ServiceRegistry.ServiceRegistry.GetService<IRegistry>();
 
-            using (var explorerKey = OpenExporerSubkey(registry.CurrentUser, RegistryKeyPermissionCheck.ReadSubTree))
+            using (var currentUser = registry.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default))
+            using (var explorerKey = OpenExporerSubkey(currentUser, RegistryKeyPermissionCheck.ReadSubTree))
             {
                 //  Do we have the value?
                 var value = explorerKey.GetValue(ValueName_DesktopProcess, null);
@@ -84,13 +86,15 @@ namespace SharpShell.Diagnostics
             if (alwaysUnloadDll)
             {
                 //  Open the explorer key and create the always unload key.
-                using (var explorerKey = OpenExporerSubkey(registry.LocalMachine, RegistryKeyPermissionCheck.ReadWriteSubTree))
+                using (var localMachine = registry.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default))
+                using (var explorerKey = OpenExporerSubkey(localMachine, RegistryKeyPermissionCheck.ReadWriteSubTree))
                     explorerKey.CreateSubKey(SubKeyName_AlwaysUnloadDLL);
             }
             else
             {
                 //  Open the explorer key and delete the always unload key.
-                using (var explorerKey = OpenExporerSubkey(registry.LocalMachine, RegistryKeyPermissionCheck.ReadWriteSubTree))
+                using (var localMachine = registry.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default))
+                using (var explorerKey = OpenExporerSubkey(localMachine, RegistryKeyPermissionCheck.ReadWriteSubTree))
                     explorerKey.DeleteSubKeyTree(SubKeyName_AlwaysUnloadDLL);
             }
         }
@@ -113,13 +117,15 @@ namespace SharpShell.Diagnostics
             if (desktopProcess)
             {
                 //  Open the explorer key and create the value.
-                using (var explorerKey = OpenExporerSubkey(registry.CurrentUser, RegistryKeyPermissionCheck.ReadWriteSubTree))
+                using (var currentUser = registry.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default))
+                using (var explorerKey = OpenExporerSubkey(currentUser, RegistryKeyPermissionCheck.ReadWriteSubTree))
                     explorerKey.SetValue(ValueName_DesktopProcess, 1, RegistryValueKind.DWord);
             }
             else
             {
                 //  Delete the key value.
-                using (var explorerKey = OpenExporerSubkey(registry.CurrentUser, RegistryKeyPermissionCheck.ReadWriteSubTree))
+                using (var currentUser = registry.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default))
+                using (var explorerKey = OpenExporerSubkey(currentUser, RegistryKeyPermissionCheck.ReadWriteSubTree))
                     explorerKey.DeleteValue(ValueName_DesktopProcess);
             }
         }

--- a/SharpShell/SharpShell/Registry/IRegistry.cs
+++ b/SharpShell/SharpShell/Registry/IRegistry.cs
@@ -17,24 +17,5 @@ namespace SharpShell.Registry
         /// <exception cref="T:System.UnauthorizedAccessException">The user does not have the necessary registry rights.</exception>
         /// <exception cref="T:System.Security.SecurityException">The user does not have the permissions required to perform this action.</exception>
         IRegistryKey OpenBaseKey(RegistryHive hKey, RegistryView view);
-
-        /// <summary>Contains information about the current user preferences. This field reads the Windows registry base key HKEY_CURRENT_USER </summary>
-        IRegistryKey CurrentUser { get; }
-
-        /// <summary>Contains the configuration data for the local machine. This field reads the Windows registry base key HKEY_LOCAL_MACHINE.</summary>
-        IRegistryKey LocalMachine { get; }
-
-        /// <summary>Defines the types (or classes) of documents and the properties associated with those types. This field reads the Windows registry base key HKEY_CLASSES_ROOT.</summary>
-        IRegistryKey ClassesRoot { get; }
-
-        /// <summary>Contains information about the default user configuration. This field reads the Windows registry base key HKEY_USERS.</summary>
-        IRegistryKey Users { get; }
-
-        /// <summary>Contains performance information for software components. This field reads the Windows registry base key HKEY_PERFORMANCE_DATA.</summary>
-        IRegistryKey PerformanceData { get; }
-
-        /// <summary>Contains configuration information pertaining to the hardware that is not specific to the user. This field reads the Windows registry base key HKEY_CURRENT_CONFIG.</summary>
-        IRegistryKey CurrentConfig { get; }
-
     }
 }

--- a/SharpShell/SharpShell/Registry/WindowsRegistry.cs
+++ b/SharpShell/SharpShell/Registry/WindowsRegistry.cs
@@ -16,23 +16,5 @@ namespace SharpShell.Registry
             var key = RegistryKey.OpenBaseKey(hKey, view);
             return new WindowsRegistryKey(key);
         }
-
-        /// <inheritdoc />
-        public IRegistryKey CurrentUser => new WindowsRegistryKey(Microsoft.Win32.Registry.CurrentUser);
-
-        /// <inheritdoc />
-        public IRegistryKey LocalMachine => new WindowsRegistryKey(Microsoft.Win32.Registry.LocalMachine);
-
-        /// <inheritdoc />
-        public IRegistryKey ClassesRoot => new WindowsRegistryKey(Microsoft.Win32.Registry.ClassesRoot);
-
-        /// <inheritdoc />
-        public IRegistryKey Users => new WindowsRegistryKey(Microsoft.Win32.Registry.Users);
-
-        /// <inheritdoc />
-        public IRegistryKey PerformanceData => new WindowsRegistryKey(Microsoft.Win32.Registry.PerformanceData);
-
-        /// <inheritdoc />
-        public IRegistryKey CurrentConfig => new WindowsRegistryKey(Microsoft.Win32.Registry.CurrentConfig);
     }
 }

--- a/SharpShell/SharpShell/ServiceRegistry/ServiceRegistry.cs
+++ b/SharpShell/SharpShell/ServiceRegistry/ServiceRegistry.cs
@@ -9,15 +9,22 @@ namespace SharpShell.ServiceRegistry
     /// </summary>
     public static class ServiceRegistry
     {
-        private static readonly Dictionary<Type, Func<object>> ServiceProviders;
+        private static readonly Dictionary<Type, Func<object>> ServiceProviders = new Dictionary<Type, Func<object>>();
 
         static ServiceRegistry()
         {
-            ServiceProviders = new Dictionary<Type, Func<object>>
-            {
-                //  By default, IRegistry is provided by WindowsRegistry.
-                {typeof(IRegistry), () => new WindowsRegistry()}
-            };
+            Reset();
+        }
+
+        /// <summary>
+        /// Resets all providers. Typically used only for testing.
+        /// </summary>
+        internal static void Reset()
+        {
+            ServiceProviders.Clear();
+
+            //  The default registry provider is a new instance of the WindowsRegitry.
+            ServiceProviders.Add(typeof(IRegistry), () => new WindowsRegistry());
         }
 
         /// <summary>
@@ -29,10 +36,7 @@ namespace SharpShell.ServiceRegistry
         public static T GetService<T>() where T:class
         {
             //  Find the provider.
-            if (!ServiceProviders.TryGetValue(typeof(T), out var provider))
-            {
-                throw new InvalidOperationException($"No provider has been registered for service type '{typeof(T).FullName}'");
-            }
+            if (!ServiceProviders.TryGetValue(typeof(T), out var provider)) throw new InvalidOperationException($"No provider has been registered for service type '{typeof(T).FullName}'");
 
             //  Use the provider to return the service instance.
             return provider() as T;

--- a/SharpShell/SharpShell/SharpPreviewHandler/PreviewHandlerRegistrar.cs
+++ b/SharpShell/SharpShell/SharpPreviewHandler/PreviewHandlerRegistrar.cs
@@ -147,7 +147,8 @@ namespace SharpShell.SharpPreviewHandler
             //  Get the registry service.
             var registry = ServiceRegistry.ServiceRegistry.GetService<IRegistry>();
 
-            using (var appIdsKey = registry.ClassesRoot.OpenSubKey("AppID", true))
+            using (var classesRoot = registry.OpenBaseKey(RegistryHive.ClassesRoot, RegistryView.Default))
+            using (var appIdsKey = classesRoot.OpenSubKey("AppID", true))
             {
                 if (appIdsKey == null)
                     throw new InvalidOperationException("An exception occured trying to open the App IDs.");
@@ -170,7 +171,8 @@ namespace SharpShell.SharpPreviewHandler
             //  Get the registry service.
             var registry = ServiceRegistry.ServiceRegistry.GetService<IRegistry>();
 
-            using (var appIdsKey = registry.ClassesRoot.OpenSubKey("AppID", true))
+            using (var classesRoot = registry.OpenBaseKey(RegistryHive.ClassesRoot, RegistryView.Default))
+            using (var appIdsKey = classesRoot.OpenSubKey("AppID", true))
             {
                 if (appIdsKey == null)
                     throw new InvalidOperationException("An exception occured trying to open the App IDs.");


### PR DESCRIPTION
These properties make an assumption about the bitness of the calling
process. This is risky, as in most places we explicitly set the bitness
we're dealing with.

This PR removes the properties in favour of the more explicit
`OpenBaseKey` call.