### PR TITLE
fix: support registration of unknown file types

### DIFF
--- a/SharpShell/Samples/ThumbnailHandler/TxtThumbnailHandler/TxtThumbnailHandler.cs
+++ b/SharpShell/Samples/ThumbnailHandler/TxtThumbnailHandler/TxtThumbnailHandler.cs
@@ -16,7 +16,7 @@ namespace TxtThumbnailHandler
     /// The TxtThumbnailHandler is a ThumbnailHandler for text files.
     /// </summary>
     [ComVisible(true)]
-    [COMServerAssociation(AssociationType.FileExtension, ".txt")]
+    [COMServerAssociation(AssociationType.ClassOfExtension, ".txt")]
     public class TxtThumbnailHandler : SharpThumbnailHandler
     {
         /// <summary>

--- a/SharpShell/SharpShell.Tests/Registry/InMemoryRegistryTests.cs
+++ b/SharpShell/SharpShell.Tests/Registry/InMemoryRegistryTests.cs
@@ -24,11 +24,11 @@ namespace SharpShell.Tests.Registry
             var print = registry.Print(RegistryView.Registry64);
             Assert.That(print, Is.EqualTo(
 @"HKEY_CURRENT_USER
+   Address
+      City = Singapore
    User
       Name = Dave
-      Number = 34
-   Address
-      City = Singapore"));
+      Number = 34"));
         }
 
         [Test]

--- a/SharpShell/SharpShell.Tests/ServerRegistration/FileExtensionClassTests.cs
+++ b/SharpShell/SharpShell.Tests/ServerRegistration/FileExtensionClassTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.Win32;
+using NUnit.Framework;
+using SharpShell.Registry;
+using SharpShell.ServerRegistration;
+
+namespace SharpShell.Tests.ServerRegistration
+{
+    public class FileExtensionClassTests
+    {
+        [Test]
+        [TestCase(null)]        // null ain't value
+        [TestCase("no_dot")]    // missing a '.' at the beginning
+        [TestCase(".")]         // no actual extension
+        public void Invalid_Exceptions_Throw_On_Get(string extension)
+        {
+            try
+            {
+                var registry = new InMemoryRegistry();
+                FileExtensionClass.Get(registry.OpenBaseKey(RegistryHive.ClassesRoot, RegistryView.Default), extension, false);
+                Assert.Fail($@"An exception should be thrown for extension '{extension}'");
+            }
+            catch (Exception exception)
+            {
+                //  We should have an exception which includes the invalid extension in the message.
+                if(!string.IsNullOrEmpty(extension))
+                    Assert.That(exception.Message, Contains.Substring(extension));
+            }
+        }
+
+        [Test]
+        public void Get_Returns_Null_For_Missing_Extensions()
+        {
+            //  Given an empty registry, we should return null for the class of any extension.
+            var registry = new InMemoryRegistry();
+            var className = FileExtensionClass.Get(registry.OpenBaseKey(RegistryHive.ClassesRoot, RegistryView.Default), ".some_type", false);
+            Assert.That(className, Is.Null);
+        }
+    }
+}

--- a/SharpShell/SharpShell.Tests/ServerRegistration/ServerRegistrationManagerTests.cs
+++ b/SharpShell/SharpShell.Tests/ServerRegistration/ServerRegistrationManagerTests.cs
@@ -162,7 +162,6 @@ namespace SharpShell.Tests.ServerRegistration
                 @"HKEY_CLASSES_ROOT",
                 @"   .myfile",
                 @"      (Default) = myfile.1",
-                @"      Content Type = application/x-msdownload",
                 @"   myfile.1",
                 @"      (Default) = myfile Application",
                 @"      ShellEx",

--- a/SharpShell/SharpShell.Tests/ServerRegistration/ServerRegistrationManagerTests.cs
+++ b/SharpShell/SharpShell.Tests/ServerRegistration/ServerRegistrationManagerTests.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.AccessControl;
+using Microsoft.Win32;
+using NUnit.Framework;
+using NUnit.Framework.Internal.Execution;
+using SharpShell.Attributes;
+using SharpShell.Extensions;
+using SharpShell.Registry;
+using SharpShell.ServerRegistration;
+
+namespace SharpShell.Tests.ServerRegistration
+{
+    public class ServerRegistrationManagerTests
+    {
+        private InMemoryRegistry _registry;
+
+        [SetUp]
+        public void SetUp()
+        {
+            //  Create a test registry, register in the service registry.
+            _registry = new InMemoryRegistry();
+            SharpShell.ServiceRegistry.ServiceRegistry.RegisterService<IRegistry>(() => _registry);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            //  Reset the service registry.
+            SharpShell.ServiceRegistry.ServiceRegistry.Reset();
+        }
+
+        [Test]
+        public void Register_Server_Associations_Uses_Appropriate_Class_Id_For_Class_Of_Extension()
+        {
+            //  Pretty important test. Given we have a file extension in the registry, assert that we
+            //  register an extension with the appropriate ProgID.
+
+            //  Prime the registry with a progid for *.exe files.
+            _registry.AddStructure(RegistryView.Registry64, string.Join(Environment.NewLine, 
+                @"HKEY_CLASSES_ROOT",
+                @"   .exe",
+                @"      (Default) = exefile",
+                @"      Content Type = application/x-msdownload",
+                @"   exefile",
+                @"      (Default) = Application"
+                ));
+
+            //  Register a context menu with an *.exe association.
+            var clsid = new Guid("00000000-1111-2222-3333-444444444444");
+            var serverType = ServerType.ShellContextMenu;
+            var serverName = "TestContextMenu";
+            var associations = new[] { new COMServerAssociationAttribute(AssociationType.ClassOfExtension, ".exe") };
+            var registrationType = RegistrationType.OS64Bit;
+            ServerRegistrationManager.RegisterServerAssociations(clsid, serverType, serverName, associations, registrationType);
+
+            //  Assert we have the new extention.
+            var print = _registry.Print(RegistryView.Registry64);
+            Assert.That(print, Is.EqualTo(string.Join(Environment.NewLine,
+                @"HKEY_CLASSES_ROOT",
+                @"   .exe",
+                @"      (Default) = exefile",
+                @"      Content Type = application/x-msdownload",
+                @"   exefile",
+                @"      (Default) = Application",
+                @"      ShellEx",
+                @"         ContextMenuHandlers",
+                @"            TestContextMenu",
+                @"               (Default) = {00000000-1111-2222-3333-444444444444}")
+            ));
+        }
+
+        [Test]
+        public void Register_Server_Associations_Creates_Class_Ids_For_Extension_Of_Class_If_Needed()
+        {
+            //  Prime the registry with a *.myfile extension but with no class id.
+            _registry.AddStructure(RegistryView.Registry64, string.Join(Environment.NewLine,
+                @"HKEY_CLASSES_ROOT",
+                @"   .myfile",                    // note that myfile has no class id...
+                @"      Content Type = text"
+            ));
+
+            //  Register a file association. Given that this registry is empty, it a new program id and then set an association.
+            var clsid = new Guid("00000000-1111-2222-3333-444444444444");
+            var serverType = ServerType.ShellContextMenu;
+            var serverName = "TestContextMenu";
+            var associations = new[] { new COMServerAssociationAttribute(AssociationType.ClassOfExtension, ".myfile") };
+            var registrationType = RegistrationType.OS64Bit;
+            ServerRegistrationManager.RegisterServerAssociations(clsid, serverType, serverName, associations, registrationType);
+
+            //  Assert we have the new extention.
+            var print = _registry.Print(RegistryView.Registry64);
+            Assert.That(print, Is.EqualTo(string.Join(Environment.NewLine,
+                @"HKEY_CLASSES_ROOT",
+                @"   .myfile",
+                @"      (Default) = myfile.1",
+                @"      Content Type = text",
+                @"   myfile.1",
+                @"      (Default) = myfile Application",
+                @"      ShellEx",
+                @"         ContextMenuHandlers",
+                @"            TestContextMenu",
+                @"               (Default) = {00000000-1111-2222-3333-444444444444}")
+            ));
+        }
+
+        [Test]
+        public void Register_Server_Associations_Fails_If_Class_Ids_For_Extension_Of_Class_Is_Already_In_Use()
+        {
+            //  Prime the registry with a *.myfile extension but with no class id. Also set up a value
+            //  for the class id we would like to use - i.e. prepare for a clash. This is a pretty specific
+            //  test but covers a potentially nasty edge case. We *could* try and dynamically generate a new
+            //  class id (myfile.2, myfile.3) and so on, but this would be pretty confusing and makes some
+            //  assumptions. Seems safer to fail with a clear reason in this case and ask the user to check
+            //  their registry. Developers might need to build a custom installer action if this actually hits
+            //  them, but it seemse pretty unlikely.
+            _registry.AddStructure(RegistryView.Registry64, string.Join(Environment.NewLine,
+                @"HKEY_CLASSES_ROOT",
+                @"   .myfile",                    // note that myfile has no class id, we will want to use myfile.1...
+                @"      Content Type = text",
+                @"   myfile.1",                   // ...uh-oh - we will want to create myfile.1, but someone else is using it.
+                @"      (Default) = Clashing Application"
+            ));
+            
+            try
+            {
+                //  Register a server.
+                var clsid = new Guid("00000000-1111-2222-3333-444444444444");
+                var serverType = ServerType.ShellContextMenu;
+                var serverName = "TestContextMenu";
+                var associations = new[] { new COMServerAssociationAttribute(AssociationType.ClassOfExtension, ".myfile") };
+                var registrationType = RegistrationType.OS64Bit;
+                ServerRegistrationManager.RegisterServerAssociations(clsid, serverType, serverName, associations, registrationType);
+                Assert.Fail(@"Server registration should fail");
+            }
+            catch (Exception exception)
+            {
+                Assert.That(exception.Message, Contains.Substring("myfile.1"), @"The exception message must contain the failing class id.");
+
+                //  TODO: I would like to see a log message asserted here, such as:
+                //  Assert.That(mostRecentLog, Contains.Substring("myfile.1"));
+                //  It might be worth considering how ILogger can work with ServiceRegistry, to simplify logging
+                //  code and make testing like this easier.
+            }
+        }
+
+        [Test]
+        public void Register_Server_Associations_Creates_File_Id_And_Class_Ids_For_Extension_Of_Class_If_Needed()
+        {
+            //  Register a file association. Given that this registry is empty, it a new program id and then set an association.
+            var clsid = new Guid("00000000-1111-2222-3333-444444444444");
+            var serverType = ServerType.ShellContextMenu;
+            var serverName = "TestContextMenu";
+            var associations = new[] {new COMServerAssociationAttribute(AssociationType.ClassOfExtension, ".myfile")};
+            var registrationType = RegistrationType.OS64Bit;
+            ServerRegistrationManager.RegisterServerAssociations(clsid, serverType, serverName, associations, registrationType);
+
+            //  Assert we have the new extention.
+            var print = _registry.Print(RegistryView.Registry64);
+            Assert.That(print, Is.EqualTo(string.Join(Environment.NewLine,
+                @"HKEY_CLASSES_ROOT",
+                @"   .myfile",
+                @"      (Default) = myfile.1",
+                @"      Content Type = application/x-msdownload",
+                @"   myfile.1",
+                @"      (Default) = myfile Application",
+                @"      ShellEx",
+                @"         ContextMenuHandlers",
+                @"            TestContextMenu",
+                @"               (Default) = {00000000-1111-2222-3333-444444444444}")
+            ));
+        }
+    }
+}

--- a/SharpShell/SharpShell.Tests/ServiceRegistry/ServiceRegistryTests.cs
+++ b/SharpShell/SharpShell.Tests/ServiceRegistry/ServiceRegistryTests.cs
@@ -6,12 +6,6 @@ namespace SharpShell.Tests.ServiceRegistry
 {
     public class ServiceRegistryTests
     {
-        [SetUp]
-        public void SetUp()
-        {
-            SharpShell.ServiceRegistry.ServiceRegistry.Reset();
-        }
-
         [Test]
         public void Default_IRegistry_Is_A_WindowsRegistry()
         {

--- a/SharpShell/SharpShell.Tests/SharpShell.Tests.csproj
+++ b/SharpShell/SharpShell.Tests/SharpShell.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Registry\WindowsRegistryKeyTests.cs" />
     <Compile Include="Registry\InMemoryRegistryTests.cs" />
     <Compile Include="Registry\WindowsRegistryTests.cs" />
+    <Compile Include="ServerRegistration\FileExtensionClassTests.cs" />
     <Compile Include="ServerRegistration\ServerRegistrationManagerTests.cs" />
     <Compile Include="ServiceRegistry\ServiceRegistryTests.cs" />
     <Compile Include="ShellInteropTests.cs" />

--- a/SharpShell/SharpShell.Tests/SharpShell.Tests.csproj
+++ b/SharpShell/SharpShell.Tests/SharpShell.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Registry\WindowsRegistryKeyTests.cs" />
     <Compile Include="Registry\InMemoryRegistryTests.cs" />
     <Compile Include="Registry\WindowsRegistryTests.cs" />
+    <Compile Include="ServerRegistration\ServerRegistrationManagerTests.cs" />
     <Compile Include="ServiceRegistry\ServiceRegistryTests.cs" />
     <Compile Include="ShellInteropTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/SharpShell/SharpShell/Attributes/AssociationType.cs
+++ b/SharpShell/SharpShell/Attributes/AssociationType.cs
@@ -1,5 +1,11 @@
-﻿namespace SharpShell.Attributes
+﻿using System;
+
+namespace SharpShell.Attributes
 {
+    //  TODO; There's a design issue here. We're mixing two concepts, the predefined shell
+    //  objects, and the concept of a 'type' of association to make. These should be separated
+    //  at some stage.
+
     /// <summary>
     /// The AssociationType determines what kind of associate a COM
     /// server is made to a class, such as a file class or a drive.
@@ -13,7 +19,10 @@
 
         /// <summary>
         /// Create an association to a specific file extension.
+        /// This attribute is deprecated. Shell extensions should not be registered directly on file extensions,
+        /// but on the class of the extension.
         /// </summary>
+        [Obsolete("FileExtension is deprecated. Use 'ClassOfExtension' instead.")]
         FileExtension,
 
         /// <summary>
@@ -27,33 +36,51 @@
         Class,
 
         /// <summary>
-        /// Create an association to the all files class.
+        /// Create an association to the 'all files' class.
         /// </summary>
+        [PredefinedShellObject(@"*")]
         AllFiles,
 
         /// <summary>
-        /// Create an association to the directory class.
+        /// Create an association to the 'all files and folders' class.
         /// </summary>
+        [PredefinedShellObject(@"AllFileSystemObjects")]
+        AllFilesAndFolders,
+
+        /// <summary>
+        /// Create an association to the 'directory' class, i.e. file-system folders.
+        /// </summary>
+        [PredefinedShellObject(@"Directory")]
         Directory,
 
         /// <summary>
         /// Create an association to the background of folders and the desktop
         /// </summary>
+        [PredefinedShellObject(@"Directory\Background")]
         DirectoryBackground,
 
         /// <summary>
         /// Create an association to the background of the desktop (Windows 7 and higher)
         /// </summary>
+        [PredefinedShellObject(@"DesktopBackground")]
         DesktopBackground,
-        
+
         /// <summary>
         /// Create an association to the drive class.
         /// </summary>
+        [PredefinedShellObject(@"Drive")]
         Drive,
+
+        /// <summary>
+        /// Create an association to the 'folder' class, i.e. all containers.
+        /// </summary>
+        [PredefinedShellObject(@"Folder")]
+        Folder,
 
         /// <summary>
         /// Create an association to the unknown files class.
         /// </summary>
+        [PredefinedShellObject(@"Unknown")]
         UnknownFiles
     }
 }

--- a/SharpShell/SharpShell/Attributes/PredefinedShellObjectAttribute.cs
+++ b/SharpShell/SharpShell/Attributes/PredefinedShellObjectAttribute.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+
+namespace SharpShell.Attributes
+{
+    /// <summary>
+    /// Provides metadata for a predefined shell object.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    internal class PredefinedShellObjectAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PredefinedShellObjectAttribute"/> class.
+        /// </summary>
+        /// <param name="className">Name of the class in the registry for this object.</param>
+        public PredefinedShellObjectAttribute(string className)
+        {
+            ClassName = className;
+        }
+
+        /// <summary>
+        /// Gets the class name for a type with a <see cref="PredefinedShellObjectAttribute"/> set, or null if none is set.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public static string GetClassName(Enum value)
+        {
+            var enumType = value.GetType();
+            var enumValueInfo = enumType.GetField(Enum.GetName(enumType, value));
+            var predefinedShellObject = enumValueInfo.GetCustomAttributes(false).OfType<PredefinedShellObjectAttribute>().FirstOrDefault();
+            return predefinedShellObject?.ClassName;
+        }
+
+        /// <summary>
+        /// Gets the class name.
+        /// </summary>
+        public string ClassName { get; }
+    }
+}

--- a/SharpShell/SharpShell/Registry/InMemoryRegistry.cs
+++ b/SharpShell/SharpShell/Registry/InMemoryRegistry.cs
@@ -131,10 +131,14 @@ namespace SharpShell.Registry
             var indent = new string(' ', depth*3);
 
             //  Get the value strings.
-            var values = key.GetValueNames().Select(v => $"{indent}{(string.IsNullOrEmpty(v) ? "(Default)" : v)} = {key.GetValue(v)}");
+            var values = key.GetValueNames()
+                .Select(v => $"{indent}{(string.IsNullOrEmpty(v) ? "(Default)" : v)} = {key.GetValue(v)}")
+                .OrderBy(s => s);
 
             //  Get the subkey strings.
-            var subKeys = key.GetSubKeyNames().Select(sk =>
+            var subKeys = key.GetSubKeyNames()
+                .OrderBy(sk => sk)
+                .Select(sk =>
                 $"{indent}{sk}{Environment.NewLine}{PrintKey(key.OpenSubKey(sk), depth + 1)}");
 
             return string.Join(Environment.NewLine, values.Concat(subKeys));
@@ -149,7 +153,7 @@ namespace SharpShell.Registry
         {
             string v = string.Empty;
             //  Go through the hives. We'll only print them if they have keys.
-            foreach (var rootKey in _rootKeys.Where(rk => rk.Key.Item1 == registryView))
+            foreach (var rootKey in _rootKeys.Where(rk => rk.Key.Item1 == registryView).OrderBy(k => k.Value.Name))
             {
                 string print = rootKey.Value.Name;
                 string val = PrintKey(rootKey.Value, 1);

--- a/SharpShell/SharpShell/ServerRegistration/FileExtensionClass.cs
+++ b/SharpShell/SharpShell/ServerRegistration/FileExtensionClass.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.Win32;
+using SharpShell.Registry;
+
+namespace SharpShell.ServerRegistration
+{
+    /// <summary>
+    /// Provides methods for manipulating the file extension classes which may be present
+    /// in the registry.
+    /// </summary>
+    public static class FileExtensionClass
+    {
+        /// <summary>
+        /// Gets the class of the given file extension, optionally creating it if it does not exist.
+        /// </summary>
+        /// <param name="classesKey">The classes key (HKEY_CLASSES_ROOT).</param>
+        /// <param name="fileExtension">The file extension, with a leading dot.</param>
+        /// <param name="createIfMissing">if set to <c>true</c> then if no class exists, one will be created.</param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException">Thrown if the extension is invalid.</exception>
+        public static string Get(IRegistryKey classesKey, string fileExtension, bool createIfMissing)
+        {
+            //  Make sure that we have a file extension, a string which starts with a dot and
+            //  has at least one character following it.
+            if (string.IsNullOrEmpty(fileExtension) ||
+                fileExtension.StartsWith(".") == false ||
+                fileExtension.Length < 2)
+            {
+                throw new InvalidOperationException($@"'{fileExtension}' does not appear to be a valid file extension class.");
+            }
+
+            //  We will need the extension with no leading dot later.
+            var extension = fileExtension.Substring(1);
+
+            //  Open or create the file extension key.
+            using (var fileExtensionClassKey =
+                classesKey.CreateSubKey(fileExtension, RegistryKeyPermissionCheck.ReadWriteSubTree))
+            {
+                //  Get the class, which is the 'default' value. If we've got a value, we're done.
+                var fileExtensionClassName = fileExtensionClassKey.GetValue(null) as string;
+                if (!string.IsNullOrEmpty(fileExtensionClassName)) return fileExtensionClassName;
+
+                //  We don't have a class for the extension. If we are *not* creating missing ones, we're done.
+                if (!createIfMissing) return null;
+
+                //  There is no file extension class name, so we'll have to create one. Set the desired class name.
+                fileExtensionClassName = $"{extension}.1"; // e.g. 'dllfile', 'mytypefile'
+
+                //  If the desired class name exists, we're going to have to bail out (we could try and find another
+                //  name, but that starts to get difficult for users to reason about).
+                using (var fileExtensionClassNameKey = classesKey.OpenSubKey(fileExtensionClassName))
+                {
+                    if (fileExtensionClassNameKey != null)
+                    {
+                        var applicationName = fileExtensionClassNameKey.GetValue(null) as string;
+                        throw new InvalidOperationException(
+                            $@"Unable to create a new class '{fileExtensionClassName}' for extension '{fileExtension}'. That class is already in use by application '{applicationName}'.");
+                    }
+                }
+
+                //  Create the file extension class name key, point the file extension to it, set a sensible name for the application and we're done.
+                using (var fileExtensionClassNameKey = classesKey.CreateSubKey(fileExtensionClassName, RegistryKeyPermissionCheck.ReadWriteSubTree))
+                {
+                    fileExtensionClassKey.SetValue(null, fileExtensionClassName);
+                    fileExtensionClassNameKey.SetValue(null, $"{extension} Application");
+                    return fileExtensionClassName;
+                }
+            }
+        }
+    }
+}

--- a/SharpShell/SharpShell/SharpShell.csproj
+++ b/SharpShell/SharpShell/SharpShell.csproj
@@ -69,6 +69,7 @@
       <Link>SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Attributes\AssociationType.cs" />
+    <Compile Include="Attributes\PredefinedShellObjectAttribute.cs" />
     <Compile Include="Attributes\RegistrationNameAttribute.cs" />
     <Compile Include="Attributes\COMServerAssociationAttribute.cs" />
     <Compile Include="Attributes\CustomUnregisterFunctionAttribute.cs" />
@@ -204,6 +205,7 @@
     <Compile Include="Registry\WindowsRegistry.cs" />
     <Compile Include="Registry\WindowsRegistryKey.cs" />
     <Compile Include="ServerRegistration\ClassRegistration.cs" />
+    <Compile Include="ServerRegistration\FileExtensionClass.cs" />
     <Compile Include="ServerRegistration\ShellExtensionType.cs" />
     <Compile Include="ServerRegistration\SpecialRegistryClass.cs" />
     <Compile Include="ServiceRegistry\ServiceRegistry.cs" />


### PR DESCRIPTION
This PR adds a set of tests which exercise server registration for the
classes of a file association in various scenarios. Two of the tests are
failing, which are demonstrations of the bugs #229, #154, #145.

Note: This PR **errors** because the tests fail. This is correct - the fix is not implement in this PR yet, only the tests which demonstrate the bug. When the tests are green, the fix is ready to go.