### PR TITLE
Fixing #298 - Bad (404) URLs in docs

### DIFF
--- a/docs/extensions/propertysheetextension/propertysheetextension.md
+++ b/docs/extensions/propertysheetextension/propertysheetextension.md
@@ -7,9 +7,9 @@ Property Sheet Extensions are Shell Extensions which add additional property she
 <!-- vim-markdown-toc GFM -->
 
 * [Creating the Project](#creating-the-project)
-* [Create the DeskBand Interface](#create-the-deskband-interface)
-* [Create the DeskBand Server](#create-the-deskband-server)
-* [Install the DeskBand Server](#install-the-deskband-server)
+* [Create the Property Sheet Server](#create-the-property-sheet-server)
+* [Create the Property Page](#create-the-property-page)
+* [Install the Server](#install-the-server)
 * [See Also](#see-also)
 
 <!-- vim-markdown-toc -->

--- a/docs/extensions/propertysheetextension/propertysheetextension.md
+++ b/docs/extensions/propertysheetextension/propertysheetextension.md
@@ -71,7 +71,7 @@ This function returns a bool. If the result is true, then the property sheet pag
 
 This function returns a set of SharpPropertyPage objects - these are the actual property pages we're going to add to the shell property sheet.
 
-We also use the `COMServerAssociation` class to associate with a specific shell object. You can find out more in the [`COMServerAssociation` documentation](./docs/com-server-associations.md).
+We also use the `COMServerAssociation` class to associate with a specific shell object. You can find out more in the [`COMServerAssociation` documentation](/docs/com-server-associations.md).
 
 The server class itself needs to be visible as COM server, so we use the `ComVisible` attribute.
 
@@ -127,7 +127,7 @@ public partial class FileTimesPropertyPage : SharpPropertyPage
 }
 ```
 
-The full implementation is in the [`Samples`](./SharpShell/Samples) folder. Note that there are set of virtual functions available to allow you to handle property sheet specific events, such as 'Apply', 'Cancel', etc.
+The full implementation is in the [`Samples`](/SharpShell/Samples) folder. Note that there are set of virtual functions available to allow you to handle property sheet specific events, such as 'Apply', 'Cancel', etc.
 
 | Function | Usage |
 |----------|-------|
@@ -142,7 +142,7 @@ The full implementation is in the [`Samples`](./SharpShell/Samples) folder. Note
 
 ## Install the Server
 
-Follow the [Installing](./docs/installing/installing.md) documentation to install the server.
+Follow the [Installing](/docs/installing/installing.md) documentation to install the server.
 
 Now restart the `explorer.exe` process. If you right click on a file, you'll have the new property sheet available in the file properties.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@ Creating Shell Extension Servers can be extremely difficult, as diagnosing issue
 
 **My Server Doesn't Show Up in Windows Explorer**
 
-First, check the troubleshooting guide in the [Installing](../installing/installing.md) documentation.
+First, check the troubleshooting guide in the [Installing](./installing/installing.md) documentation.
 
 **Important:** For most SharpShell servers to work on anything other than a development machine, they MUST be built in Release Mode against the Release Mode SharpShell binary. This binary uses an unmanaged C++ component that has a dependency to MSVCRTD100.dll in debug mode - this will NOT be present on none-development machines.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,6 +43,10 @@ For property sheet extensions to work, make sure that the destination machine ha
 
 It seems that under some circumstances, Tab Controls in property sheet extensions can lead to unpredictable behaviour and crashes - currently I recommend against using them until the route cause of this issue is identified. More detail on this issue and the one above can be found here: [https://sharpshell.codeplex.com/discussions/470807](https://sharpshell.codeplex.com/discussions/470807)
 
+>...2) The second issue I found with the PropertyPageHandler is in combination with a TabControl. It doesn't matter if the TabPages are created dynamically or in static way. 
+When I switched (on my developer machine) between the PropertyPage and any other application (sometimes 2 times focus switch, sometimes after 10 times focus switches between the applications) the PropertyPage freezes and then the Windows Explorer crashes with an AppHangB1. Fast workaround is of course the usage of any other controls. I have this tested this only on one machine (my developer machine), so maybe this is only a very specific issue. 
+Thread #470807 | Message #1127814 | 2013-11-22
+
 **Context Menu Extensions**
 
 It seems that sometimes creating the [ComServerAssociation] is not enough. <span style="font-size:10pt">When you add the registry key for the given extension, the context menu may be got from a different part of the registry for the users preference. For example, for 'png', u</span><span style="font-size:10pt">ou can determine this by checking the user choice:</span>


### PR DESCRIPTION
Fixing #298 - Bad (404) URLs in docs
See commits, multiple pages, not just the one mentioned in #298.