### PR TITLE
feat: allow the name of a ComStream to be accessed, if available

### DIFF
--- a/SharpShell/Samples/ThumbnailHandler/TxtThumbnailHandler/TxtThumbnailHandler.cs
+++ b/SharpShell/Samples/ThumbnailHandler/TxtThumbnailHandler/TxtThumbnailHandler.cs
@@ -38,6 +38,8 @@ namespace TxtThumbnailHandler
         /// </returns>
         protected override Bitmap GetThumbnailImage(uint width)
         {
+            Log($"Creating thumbnail for '{SelectedItemStream.Name}'");
+
             //  Attempt to open the stream with a reader.
             try
             {

--- a/SharpShell/SharpShell/Helpers/ComStream.cs
+++ b/SharpShell/SharpShell/Helpers/ComStream.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using STATSTG = System.Runtime.InteropServices.ComTypes.STATSTG;
 
+
 namespace SharpShell.Helpers
 {
     /// <summary>
@@ -171,21 +172,6 @@ namespace SharpShell.Helpers
         }
 
         /// <summary>
-        /// When overridden in a derived class, gets the length in bytes of the stream.
-        /// </summary>
-        /// <returns>A long value representing the length of the stream in bytes.</returns>
-        public override long Length
-        {
-            get
-            {
-                //  Get the statistics of the COM stream, return the size.
-                STATSTG stat;
-                comStream.Stat(out stat, 1);
-                return stat.cbSize;
-            }
-        }
-
-        /// <summary>
         /// When overridden in a derived class, gets or sets the position within the current stream.
         /// </summary>
         /// <returns>The current position within the stream.</returns>
@@ -195,6 +181,34 @@ namespace SharpShell.Helpers
         {
             get { return position; }
             set { Seek(value, SeekOrigin.Begin); }
+        }
+
+        /// <summary>
+        /// Get the length of the stream - if possible.
+        /// </summary>
+        /// <returns>A long value representing the length of the stream in bytes.</returns>
+        public override long Length
+        {
+            get
+            {
+                //  Get the statistics of the COM stream, return the size. No need for the name.
+                comStream.Stat(out var stat, (int)STATFLAG.STATFLAG_NONAME);
+                return stat.cbSize;
+            }
+        }
+
+        /// <summary>
+        /// Get the name of the item associated with the stream, if one exists.
+        /// </summary>
+        /// <returns>A long value representing the length of the stream in bytes.</returns>
+        public string Name
+        {
+            get
+            {
+                //  Get the statistics of the COM stream, including the name.
+                comStream.Stat(out var stat, (int)STATFLAG.STATFLAG_DEFAULT);
+                return stat.pwcsName;
+            }
         }
     }
 }

--- a/SharpShell/SharpShell/Helpers/STATFLAG.cs
+++ b/SharpShell/SharpShell/Helpers/STATFLAG.cs
@@ -1,0 +1,28 @@
+﻿namespace SharpShell.Helpers
+{
+    /// <summary>
+    /// The STATFLAG enumeration values indicate whether the method should try to return a name in 
+    /// the pwcsName member of the STATSTG structure.  The values are used in the ILockBytes::Stat, 
+    /// IStorage::Stat, and IStream::Stat methods to save memory when the pwcsName member is not required.
+    /// </summary>
+    internal enum STATFLAG : int
+    {
+        /// <summary>
+        /// Requests that the statistics include the pwcsName member of the STATSTG structure.
+        /// </summary>
+        STATFLAG_DEFAULT = 0,
+
+        /// <summary>
+        /// Requests that the statistics not include the pwcsName member of the STATSTG structure. 
+        /// If the name is omitted, there is no need for the ILockBytes::Stat, IStorage::Stat, and 
+        /// IStream::Stat methods methods to allocate and free memory for the string value of the name, 
+        /// therefore the method reduces time and resources used in an allocation and free operation.
+        /// </summary>
+        STATFLAG_NONAME = 1,
+
+        /// <summary>
+        /// Not implemented.
+        /// </summary>
+        STATFLAG_NOOPEN = 2
+    }
+}

--- a/SharpShell/SharpShell/SharpShell.csproj
+++ b/SharpShell/SharpShell/SharpShell.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Extensions\IDataObjectExtensions.cs" />
     <Compile Include="Helpers\ComStream.cs" />
     <Compile Include="Helpers\RegAsm.cs" />
+    <Compile Include="Helpers\STATFLAG.cs" />
     <Compile Include="Helpers\Win32Helper.cs" />
     <Compile Include="InitializeWithStreamServer.cs" />
     <Compile Include="Interop\ASSOCCLASS.cs" />


### PR DESCRIPTION
This change allows the name of an object associated with an IStream to
be accessed via the ComStream.Name property.

As an example, the following code is used in `TxtThumbnailHandler`:

```cs
Log($"Creating thumbnail for '{SelectedItemStream.Name}'");
```

Generates:

```
2019-10-30 13:29:01.626Z - dllhost - TxtThumbnailHandler: Creating thumbnail for 'Full Regression Test.txt'
```