### PR TITLE
feat: support for shell thumbnail handlers using files

### DIFF
--- a/SharpShell/Samples/ThumbnailHandler/TxtThumbnailHandler/HtmlFileThumbnailHandler.cs
+++ b/SharpShell/Samples/ThumbnailHandler/TxtThumbnailHandler/HtmlFileThumbnailHandler.cs
@@ -14,16 +14,16 @@ using TxtThumbnailHandler.Renderer;
 namespace TxtThumbnailHandler
 {
     /// <summary>
-    /// The TxtThumbnailHandler is a ThumbnailHandler for text files.
+    /// The HtmlFileThumbnailHandler is a SharpFileThumbnailHandler for text files.
+    ///
+    /// Note that the SharpFileThumbnailHandler is less performant than the <see cref="SharpThumbnailHandler"/>,
+    /// which uses streams for its implementation, but may be required if you need the full file path.
     /// </summary>
     [ComVisible(true)]
     [COMServerAssociation(AssociationType.ClassOfExtension, ".txt")]
-    public class TxtThumbnailHandler : SharpThumbnailHandler, IDisposable
+    public class HtmlFileThumbnailHandler : SharpFileThumbnailHandler, IDisposable
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TxtThumbnailHandler"/> class.
-        /// </summary>
-        public TxtThumbnailHandler()
+        public HtmlFileThumbnailHandler()
         {
             _renderer = new TextThumbnailRenderer();
         }
@@ -37,12 +37,14 @@ namespace TxtThumbnailHandler
         /// </returns>
         protected override Bitmap GetThumbnailImage(uint width)
         {
-            Log($"Creating thumbnail for '{SelectedItemStream.Name}'");
+            Log($"Creating thumbnail for '{Path.GetFileName(SelectedItemPath)}'");
+
+            //  Grab up to three lines of HTML.
 
             //  Attempt to open the stream with a reader.
             try
             {
-                using(var reader = new StreamReader(SelectedItemStream))
+                using(var reader = new StreamReader(SelectedItemPath))
                 {
                     //  Read up to ten lines of text.
                     var previewLines = new List<string>();

--- a/SharpShell/Samples/ThumbnailHandler/TxtThumbnailHandler/Renderer/TextThumbnailRenderer.cs
+++ b/SharpShell/Samples/ThumbnailHandler/TxtThumbnailHandler/Renderer/TextThumbnailRenderer.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Drawing.Text;
+
+namespace TxtThumbnailHandler.Renderer
+{
+    internal class TextThumbnailRenderer : IDisposable
+    {
+        public TextThumbnailRenderer()
+        {
+            _textFont = new Font("Courier New", 12f);
+            _textBrush = new SolidBrush(Color.Black);
+        }
+
+        /// <summary>
+        /// Creates the thumbnail for text, using the provided preview lines.
+        /// </summary>
+        /// <param name="previewLines">The preview lines.</param>
+        /// <param name="width">The width.</param>
+        /// <returns>
+        /// A thumbnail for the text.
+        /// </returns>
+        public Bitmap CreateThumbnailForText(IEnumerable<string> previewLines, uint width)
+        {
+            //  Create the bitmap dimensions.
+            var thumbnailSize = new Size((int)width, (int)width);
+
+            //  Create the bitmap.
+            var bitmap = new Bitmap(thumbnailSize.Width, thumbnailSize.Height, PixelFormat.Format32bppArgb);
+
+            //  Create a graphics object to render to the bitmap.
+            using (var graphics = Graphics.FromImage(bitmap))
+            {
+                //  Set the rendering up for anti-aliasing.
+                graphics.TextRenderingHint = TextRenderingHint.AntiAlias;
+
+                //  Draw the page background.
+                graphics.DrawImage(Properties.Resources.Page, 0, 0, thumbnailSize.Width, thumbnailSize.Height);
+
+                //  Create offsets for the text.
+                var xOffset = width * 0.2f;
+                var yOffset = width * 0.3f;
+                var yLimit = width - yOffset;
+
+                graphics.Clip = new Region(new RectangleF(xOffset, yOffset, thumbnailSize.Width - (xOffset * 2), thumbnailSize.Height - width * .1f));
+
+                //  Render each line of text.
+                foreach (var line in previewLines)
+                {
+                    graphics.DrawString(line, _textFont, _textBrush, xOffset, yOffset);
+                    yOffset += 14f;
+                    if (yOffset + 14f > yLimit)
+                        break;
+                }
+            }
+
+            //  Return the bitmap.
+            return bitmap;
+        }
+
+        public void Dispose()
+        {
+            _textFont?.Dispose();
+            _textBrush?.Dispose();
+        }
+
+        private readonly Font _textFont;
+        private readonly Brush _textBrush;
+    }
+}

--- a/SharpShell/Samples/ThumbnailHandler/TxtThumbnailHandler/TxtThumbnailHandler.csproj
+++ b/SharpShell/Samples/ThumbnailHandler/TxtThumbnailHandler/TxtThumbnailHandler.csproj
@@ -63,6 +63,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="HtmlFileThumbnailHandler.cs" />
+    <Compile Include="Renderer\TextThumbnailRenderer.cs" />
     <Compile Include="TxtThumbnailHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/SharpShell/SharpShell/Helpers/ComStream.cs
+++ b/SharpShell/SharpShell/Helpers/ComStream.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using SharpShell.Interop;
 using STATSTG = System.Runtime.InteropServices.ComTypes.STATSTG;
 
 

--- a/SharpShell/SharpShell/InitializeWithFileServer.cs
+++ b/SharpShell/SharpShell/InitializeWithFileServer.cs
@@ -1,0 +1,41 @@
+﻿using SharpShell.Interop;
+
+namespace SharpShell
+{
+    /// <summary>
+    /// InitializeWithFileServer provides a base for SharpShell Servers that must implement
+    /// IInitializeWithFile (thumbnail handlers which need a file path for initialisation etc).
+    /// Note that if possible, <see cref="InitializeWithStreamServer"/> should be used, as it is far more
+    /// performant.
+    /// </summary>
+    public abstract class InitializeWithFileServer : SharpShellServer, IInitializeWithFile
+    {
+        #region Implementation of IInitializeWithFile
+
+        public int Initialize(string pszFilePath, STGM grfMode)
+        {
+            Log($"Intiailising a file based server for '{pszFilePath}' with mode '{grfMode}'.");
+
+            //  Store the path and mode.
+            SelectedItemPath = pszFilePath;
+            SelectedItemStorageMedium = grfMode;
+
+            //  Return success.
+            return WinError.S_OK;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Gets the selected item stream.
+        /// </summary>
+        /// <value>
+        /// The selected item stream.
+        /// </value>
+        public string SelectedItemPath { get; private set; }
+
+        /// <summary>Gets the selected item storage medium.</summary>
+        /// <value>The selected item storage medium.</value>
+        public STGM SelectedItemStorageMedium { get; private set; }
+    }
+}

--- a/SharpShell/SharpShell/Interop/STATFLAG.cs
+++ b/SharpShell/SharpShell/Interop/STATFLAG.cs
@@ -1,4 +1,4 @@
-﻿namespace SharpShell.Helpers
+﻿namespace SharpShell.Interop
 {
     /// <summary>
     /// The STATFLAG enumeration values indicate whether the method should try to return a name in 

--- a/SharpShell/SharpShell/ServerType.cs
+++ b/SharpShell/SharpShell/ServerType.cs
@@ -66,6 +66,12 @@ namespace SharpShell
         /// </summary>
         [Description("Shell Thumbnail Handler")]
         ShellThumbnailHandler,
+        
+        /// <summary>
+        /// A Shell File Thumbnail Handler (as opposed to the standard stream handler).
+        /// </summary>
+        [Description("Shell File Thumbnail Handler")]
+        ShellFileThumbnailHandler,
 
         /// <summary>
         /// A Shell Namespace Extension
@@ -77,6 +83,6 @@ namespace SharpShell
         /// A Shell Desk Band Extension
         /// </summary>
         [Description("Shell Desk Band Extension")]
-        ShellDeskBand
+        ShellDeskBand,
     }
 }

--- a/SharpShell/SharpShell/SharpShell.csproj
+++ b/SharpShell/SharpShell/SharpShell.csproj
@@ -93,7 +93,8 @@
     <Compile Include="Extensions\IDataObjectExtensions.cs" />
     <Compile Include="Helpers\ComStream.cs" />
     <Compile Include="Helpers\RegAsm.cs" />
-    <Compile Include="Helpers\STATFLAG.cs" />
+    <Compile Include="InitializeWithFileServer.cs" />
+    <Compile Include="Interop\STATFLAG.cs" />
     <Compile Include="Helpers\Win32Helper.cs" />
     <Compile Include="InitializeWithStreamServer.cs" />
     <Compile Include="Interop\ASSOCCLASS.cs" />
@@ -256,6 +257,7 @@
     </Compile>
     <Compile Include="Helpers\BitmapHelper.cs" />
     <Compile Include="Interop\DIB.cs" />
+    <Compile Include="SharpThumbnailHandler\SharpFileThumbnailHandler.cs" />
     <Compile Include="SharpThumbnailHandler\SharpThumbnailHandler.cs" />
     <Compile Include="ShellExtInitServer.cs" />
     <Compile Include="SharpDropHandler\SharpDropHandler.cs" />

--- a/SharpShell/SharpShell/SharpShellServer.cs
+++ b/SharpShell/SharpShell/SharpShellServer.cs
@@ -86,6 +86,15 @@ namespace SharpShell
             if (!string.IsNullOrEmpty(displayName))
                 ServerRegistrationManager.SetServerDisplayName(type.GUID, displayName, registrationType);
 
+            //  If we are a *file* thumbnail handler, we must disable process isolation.
+            //  See: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/cc144118(v%3Dvs.85)#thumbnail-processes
+            if (serverType == ServerType.ShellFileThumbnailHandler || serverType == ServerType.ShellThumbnailHandler)
+            {
+                Logging.Log($"Disabling process isolation for SharpFileThumbnailHandler named '{type.Name}'.");
+                ServerRegistrationManager.SetDisableProcessIsolationValue(type.GUID, registrationType, 1 /* i.e. disabled */);
+
+            }
+
             //  Execute the custom register function, if there is one.
             CustomRegisterFunctionAttribute.ExecuteIfExists(type, registrationType);
 

--- a/SharpShell/SharpShell/SharpThumbnailHandler/SharpFileThumbnailHandler.cs
+++ b/SharpShell/SharpShell/SharpThumbnailHandler/SharpFileThumbnailHandler.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.IO;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
+using SharpShell.Attributes;
+using SharpShell.Interop;
+
+namespace SharpShell.SharpThumbnailHandler
+{
+    /// <summary>
+    /// The SharpIconHandler is the base class for SharpShell servers that provide
+    /// custom Thumbnail Image Handlers.
+    /// </summary>
+    [ServerType(ServerType.ShellFileThumbnailHandler)]
+    public abstract class SharpFileThumbnailHandler : InitializeWithFileServer, IThumbnailProvider
+    {
+        /// <summary>
+        /// Gets a thumbnail image and alpha type.
+        /// </summary>
+        /// <param name="cx">The maximum thumbnail size, in pixels. The Shell draws the returned bitmap at this size or smaller. The returned bitmap should fit into a square of width and height cx, though it does not need to be a square image. The Shell scales the bitmap to render at lower sizes. For example, if the image has a 6:4 aspect ratio, then the returned bitmap should also have a 6:4 aspect ratio.</param>
+        /// <param name="phbmp">When this method returns, contains a pointer to the thumbnail image handle. The image must be a DIB section and 32 bits per pixel. The Shell scales down the bitmap if its width or height is larger than the size specified by cx. The Shell always respects the aspect ratio and never scales a bitmap larger than its original size.</param>
+        /// <param name="pdwAlpha">When this method returns, contains a pointer to one of the following values from the WTS_ALPHATYPE enumeration.</param>
+        /// <returns>
+        /// If this method succeeds, it returns S_OK. Otherwise, it returns an HRESULT error code.
+        /// </returns>
+        /// <exception cref="System.NotImplementedException"></exception>
+        int IThumbnailProvider.GetThumbnail(uint cx, out IntPtr phbmp, out WTS_ALPHATYPE pdwAlpha)
+        {
+            //  DebugLog this key event.
+            Log($"GetThumbnail for file '{SelectedItemPath}', width {cx}.");
+
+            //  Set the out variables to default values.
+            phbmp = IntPtr.Zero;
+            pdwAlpha = WTS_ALPHATYPE.WTSAT_UNKNOWN;
+            Bitmap thumbnailImage;
+
+            try
+            {
+                //  Get the thumbnail image.
+                thumbnailImage = GetThumbnailImage(cx);
+            }
+            catch(Exception exception)
+            {
+                //  DebugLog the exception and return failure.
+                LogError("An exception occured when getting the thumbnail image.", exception);
+                return WinError.E_FAIL;
+            }
+
+            //  If we couldn't get an image, return failure.
+            if(thumbnailImage == null)
+            {
+                //  DebugLog a warning return failure.
+                Log("The internal GetThumbnail function failed to return a valid thumbnail.");
+                return WinError.E_FAIL;
+            }
+
+            //  Now we can set the image.
+            phbmp = thumbnailImage.GetHbitmap();
+            pdwAlpha = WTS_ALPHATYPE.WTSAT_ARGB;
+          
+            //  Return success.
+            return WinError.S_OK;
+        }
+
+        /// <summary>
+        /// Gets the thumbnail image for the currently selected item (SelectedItemStream).
+        /// </summary>
+        /// <param name="width">The width of the image that should be returned.</param>
+        /// <returns>The image for the thumbnail.</returns>
+        protected abstract Bitmap GetThumbnailImage(uint width);
+    }
+}

--- a/SharpShell/Tools/ServerManager/ServerManagerForm.cs
+++ b/SharpShell/Tools/ServerManager/ServerManagerForm.cs
@@ -367,6 +367,7 @@ namespace ServerManager
                         SelectedServerEntry.Server is SharpDropHandler ||
                         SelectedServerEntry.Server is SharpPreviewHandler ||
                         SelectedServerEntry.Server is SharpThumbnailHandler ||
+                        SelectedServerEntry.Server is SharpFileThumbnailHandler ||
                         SelectedServerEntry.Server is SharpIconOverlayHandler
                     )
                 );


### PR DESCRIPTION
Note that although this implementation is correct, on Windows 10 you cannot initialise thumbnail handlers from files:

https://social.msdn.microsoft.com/Forums/en-US/80617ead-f9c4-422a-a405-06fd3837f7be/problem-about-iinitializewithfile-ithumbnailprovider?forum=windowssearch

It is a security flaw and has therefore been disabled. This PR will not be going in, but left for discussion for alternative approaches. See also:

https://github.com/dwmkerr/sharpshell/issues/38