### PR TITLE
Preliminary approach to insert outer menu items at system-provided po…

### DIFF
--- a/SharpShell/SharpShell/SharpContextMenu/NativeContextMenuWrapper.cs
+++ b/SharpShell/SharpShell/SharpContextMenu/NativeContextMenuWrapper.cs
@@ -27,14 +27,20 @@ namespace SharpShell.SharpContextMenu
         /// Builds a native context menu, on to the provided HMENU.
         /// </summary>
         /// <param name="hMenu">The handle to the menu.</param>
+        /// <param name="itemIndex">The zero-based position at which to insert the first new menu item.</param>
         /// <param name="firstItemId">The first item id.</param>
         /// <param name="toolStripItems">The tool strip menu items.</param>
+        /// <param name="reserved">Reserved, do not use.</param>
         /// <returns>The index of the last item created.</returns>
-        public uint BuildNativeContextMenu(IntPtr hMenu, uint firstItemId, ToolStripItemCollection toolStripItems)
+        public uint BuildNativeContextMenu(IntPtr hMenu, uint itemIndex, uint firstItemId, ToolStripItemCollection toolStripItems, int reserved = 1)
         {
             //  Create an ID counter and position counter.
             var idCounter = firstItemId;
             uint positionCounter = 0;
+
+            // We'll insert only outer elements.
+            var insert = Convert.ToBoolean(reserved);
+            if (insert) positionCounter = itemIndex;
 
             //  Go through every tool strip item.
             foreach (ToolStripItem item in toolStripItems)
@@ -68,7 +74,7 @@ namespace SharpShell.SharpContextMenu
                 if (toolStripMenuItem != null && toolStripMenuItem.HasDropDownItems)
                 {
                     //  Create each drop down item.
-                    idCounter = BuildNativeContextMenu(menuItemInfo.hSubMenu, idCounter, toolStripMenuItem.DropDownItems);
+                    idCounter = BuildNativeContextMenu(menuItemInfo.hSubMenu, itemIndex, idCounter, toolStripMenuItem.DropDownItems, 0);
                 }
             }
 

--- a/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
+++ b/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Security.Policy;
@@ -64,22 +63,6 @@ namespace SharpShell.SharpContextMenu
 
                 //  Return the failure.
                 return WinError.E_FAIL;
-            }
-
-            // Give context menu a chance to position itself.
-            var menuItemCount = GetMenuItemCount(hMenu);
-            if (menuItemCount == -1)
-            {
-                LogError("Couldn't get menu item count.", new Win32Exception()); // this constructor pulls human-friendly message
-            }
-            else
-            {
-                var userMenuIndex = GetMenuIndex(menuItemCount);
-                if (userMenuIndex != null)
-                {
-                    var value = Math.Min(Math.Max(userMenuIndex.Value, 0), menuItemCount);
-                    indexMenu = Convert.ToUInt32(value);
-                }
             }
 
             //  Set the first item id.
@@ -369,23 +352,6 @@ namespace SharpShell.SharpContextMenu
         /// </summary>
         /// <returns>The context menu for the shell context menu.</returns>
         protected abstract ContextMenuStrip CreateMenu();
-
-        [DllImport("User32.dll", SetLastError = true)]
-        private static extern int GetMenuItemCount(IntPtr hMenu);
-
-        /// <summary>
-        ///     Offers an opportunity to this instance to position itself in the context menu to be displayed by the system.
-        /// </summary>
-        /// <param name="count">Number of items in the context menu to be displayed by the system.</param>
-        /// <returns>
-        ///     A value between zero and less than <paramref name="count" /> to choose a position,
-        ///     <c>null</c> to let the system position this instance.
-        ///     The default implementation returns <c>null</c>.
-        /// </returns>
-        protected virtual int? GetMenuIndex(int count)
-        {
-            return null;
-        }
 
         /// <summary>
         /// Called when the context menu is about to be displayed.

--- a/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
+++ b/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
@@ -74,43 +74,11 @@ namespace SharpShell.SharpContextMenu
             }
             else
             {
-                // by index
                 var userMenuIndex = GetMenuIndex(menuItemCount);
                 if (userMenuIndex != null)
                 {
                     var value = Math.Min(Math.Max(userMenuIndex.Value, 0), menuItemCount);
                     indexMenu = Convert.ToUInt32(value);
-                }
-                else // by captions
-                {
-                    var captions = new string[menuItemCount];
-
-                    for (var i = 0u; i < menuItemCount; i++)
-                    {
-                        var info = new MENUITEMINFOW();
-                        info.cbSize = (uint) Marshal.SizeOf(info);
-                        info.fMask = (uint) MIIM.MIIM_STRING;
-
-                        if (!GetMenuItemInfo(hMenu, i, true, ref info))
-                            continue;
-
-                        var mem = Marshal.AllocCoTaskMem(((int) info.cch + 1) * sizeof(char));
-
-                        info.dwTypeData = mem;
-                        info.cch++;
-
-                        if (GetMenuItemInfo(hMenu, i, true, ref info))
-                            captions[i] = Marshal.PtrToStringAuto(mem);
-
-                        Marshal.FreeCoTaskMem(mem);
-                    }
-
-                    var menuIndex = GetMenuIndex(captions);
-                    if (menuIndex != null)
-                    {
-                        var value = Math.Min(Math.Max(menuIndex.Value, 0), menuItemCount);
-                        indexMenu = Convert.ToUInt32(value);
-                    }
                 }
             }
 
@@ -402,28 +370,6 @@ namespace SharpShell.SharpContextMenu
         /// <returns>The context menu for the shell context menu.</returns>
         protected abstract ContextMenuStrip CreateMenu();
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct MENUITEMINFOW
-        {
-            public uint cbSize;
-            public uint fMask;
-            public uint fType;
-            public uint fState;
-            public uint wID;
-            public IntPtr hSubMenu;
-            public IntPtr hbmpChecked;
-            public IntPtr hbmpUnchecked;
-            public uint dwItemData;
-            public IntPtr dwTypeData;
-            public uint cch;
-            public IntPtr hbmpItem;
-        }
-
-        [DllImport("User32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool GetMenuItemInfo(
-            IntPtr hMenu, uint item, [MarshalAs(UnmanagedType.Bool)] bool fByPosition, ref MENUITEMINFOW lpmii);
-
         [DllImport("User32.dll", SetLastError = true)]
         private static extern int GetMenuItemCount(IntPtr hMenu);
 
@@ -437,22 +383,6 @@ namespace SharpShell.SharpContextMenu
         ///     The default implementation returns <c>null</c>.
         /// </returns>
         protected virtual int? GetMenuIndex(int count)
-        {
-            return null;
-        }
-
-        /// <summary>
-        ///     Offers an opportunity to this instance to position itself in the context menu to be displayed by the system.
-        /// </summary>
-        /// <param name="captions">
-        ///     Captions of context menu entries to be displayed by the system.
-        /// </param>
-        /// <returns>
-        ///     A value between zero and less than <paramref name="captions" /> <see cref="string.Length" /> to choose a position,
-        ///     <c>null</c> to let the system position this instance.
-        ///     The default implementation returns <c>null</c>.
-        /// </returns>
-        protected virtual int? GetMenuIndex(string[] captions)
         {
             return null;
         }

--- a/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
+++ b/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
@@ -402,31 +402,6 @@ namespace SharpShell.SharpContextMenu
         /// <returns>The context menu for the shell context menu.</returns>
         protected abstract ContextMenuStrip CreateMenu();
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct MENUITEMINFOW
-        {
-            public uint cbSize;
-            public uint fMask;
-            public uint fType;
-            public uint fState;
-            public uint wID;
-            public IntPtr hSubMenu;
-            public IntPtr hbmpChecked;
-            public IntPtr hbmpUnchecked;
-            public uint dwItemData;
-            public IntPtr dwTypeData;
-            public uint cch;
-            public IntPtr hbmpItem;
-        }
-
-        [DllImport("User32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool GetMenuItemInfo(
-            IntPtr hMenu, uint item, [MarshalAs(UnmanagedType.Bool)] bool fByPosition, ref MENUITEMINFOW lpmii);
-
-        [DllImport("User32.dll", SetLastError = true)]
-        private static extern int GetMenuItemCount(IntPtr hMenu);
-
         /// <summary>
         ///     Offers an opportunity to this instance to position itself in the context menu to be displayed by the system.
         /// </summary>
@@ -481,5 +456,38 @@ namespace SharpShell.SharpContextMenu
         /// The current invoke command information.
         /// </summary>
         private InvokeCommandInfo currentInvokeCommandInfo;
+
+        #region Interop
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MenuItemInfoW
+        {
+            // ReSharper disable MemberCanBePrivate.Local
+            // ReSharper disable FieldCanBeMadeReadOnly.Local
+            public uint cbSize;
+            public uint fMask;
+            public uint fType;
+            public uint fState;
+            public uint wID;
+            public IntPtr hSubMenu;
+            public IntPtr hbmpChecked;
+            public IntPtr hbmpUnchecked;
+            public uint dwItemData;
+            public IntPtr dwTypeData;
+            public uint cch;
+            public IntPtr hbmpItem;
+            // ReSharper restore MemberCanBePrivate.Local
+            // ReSharper restore FieldCanBeMadeReadOnly.Local
+        }
+
+        [DllImport("User32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetMenuItemInfo(
+            IntPtr hMenu, uint item, [MarshalAs(UnmanagedType.Bool)] bool fByPosition, ref MenuItemInfoW lpmii);
+
+        [DllImport("User32.dll", SetLastError = true)]
+        private static extern int GetMenuItemCount(IntPtr hMenu);
+
+        #endregion
     }
 }

--- a/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
+++ b/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
@@ -73,7 +73,7 @@ namespace SharpShell.SharpContextMenu
             try
             {
                 nativeContextMenuWrapper.ResetNativeContextMenu();
-                lastItemId = nativeContextMenuWrapper.BuildNativeContextMenu(hMenu, firstItemId, contextMenuStrip.Value.Items);
+                lastItemId = nativeContextMenuWrapper.BuildNativeContextMenu(hMenu, indexMenu, firstItemId, contextMenuStrip.Value.Items);
             }
             catch (Exception exception)
             {

--- a/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
+++ b/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
@@ -402,6 +402,31 @@ namespace SharpShell.SharpContextMenu
         /// <returns>The context menu for the shell context menu.</returns>
         protected abstract ContextMenuStrip CreateMenu();
 
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MENUITEMINFOW
+        {
+            public uint cbSize;
+            public uint fMask;
+            public uint fType;
+            public uint fState;
+            public uint wID;
+            public IntPtr hSubMenu;
+            public IntPtr hbmpChecked;
+            public IntPtr hbmpUnchecked;
+            public uint dwItemData;
+            public IntPtr dwTypeData;
+            public uint cch;
+            public IntPtr hbmpItem;
+        }
+
+        [DllImport("User32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetMenuItemInfo(
+            IntPtr hMenu, uint item, [MarshalAs(UnmanagedType.Bool)] bool fByPosition, ref MENUITEMINFOW lpmii);
+
+        [DllImport("User32.dll", SetLastError = true)]
+        private static extern int GetMenuItemCount(IntPtr hMenu);
+
         /// <summary>
         ///     Offers an opportunity to this instance to position itself in the context menu to be displayed by the system.
         /// </summary>
@@ -456,38 +481,5 @@ namespace SharpShell.SharpContextMenu
         /// The current invoke command information.
         /// </summary>
         private InvokeCommandInfo currentInvokeCommandInfo;
-
-        #region Interop
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct MenuItemInfoW
-        {
-            // ReSharper disable MemberCanBePrivate.Local
-            // ReSharper disable FieldCanBeMadeReadOnly.Local
-            public uint cbSize;
-            public uint fMask;
-            public uint fType;
-            public uint fState;
-            public uint wID;
-            public IntPtr hSubMenu;
-            public IntPtr hbmpChecked;
-            public IntPtr hbmpUnchecked;
-            public uint dwItemData;
-            public IntPtr dwTypeData;
-            public uint cch;
-            public IntPtr hbmpItem;
-            // ReSharper restore MemberCanBePrivate.Local
-            // ReSharper restore FieldCanBeMadeReadOnly.Local
-        }
-
-        [DllImport("User32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool GetMenuItemInfo(
-            IntPtr hMenu, uint item, [MarshalAs(UnmanagedType.Bool)] bool fByPosition, ref MenuItemInfoW lpmii);
-
-        [DllImport("User32.dll", SetLastError = true)]
-        private static extern int GetMenuItemCount(IntPtr hMenu);
-
-        #endregion
     }
 }

--- a/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
+++ b/SharpShell/SharpShell/SharpContextMenu/SharpContextMenu.cs
@@ -66,10 +66,53 @@ namespace SharpShell.SharpContextMenu
                 return WinError.E_FAIL;
             }
 
-            // Give user a chance to position menu manually.
-            var userIndex = TryGetUserIndexMenu(hMenu);
-            if (userIndex != -1)
-                indexMenu = Convert.ToUInt32(userIndex);
+            // Give context menu a chance to position itself.
+            var menuItemCount = GetMenuItemCount(hMenu);
+            if (menuItemCount == -1)
+            {
+                LogError("Couldn't get menu item count.", new Win32Exception()); // this constructor pulls human-friendly message
+            }
+            else
+            {
+                // by index
+                var userMenuIndex = GetMenuIndex(menuItemCount);
+                if (userMenuIndex != null)
+                {
+                    var value = Math.Min(Math.Max(userMenuIndex.Value, 0), menuItemCount);
+                    indexMenu = Convert.ToUInt32(value);
+                }
+                else // by captions
+                {
+                    var captions = new string[menuItemCount];
+
+                    for (var i = 0u; i < menuItemCount; i++)
+                    {
+                        var info = new MENUITEMINFOW();
+                        info.cbSize = (uint) Marshal.SizeOf(info);
+                        info.fMask = (uint) MIIM.MIIM_STRING;
+
+                        if (!GetMenuItemInfo(hMenu, i, true, ref info))
+                            continue;
+
+                        var mem = Marshal.AllocCoTaskMem(((int) info.cch + 1) * sizeof(char));
+
+                        info.dwTypeData = mem;
+                        info.cch++;
+
+                        if (GetMenuItemInfo(hMenu, i, true, ref info))
+                            captions[i] = Marshal.PtrToStringAuto(mem);
+
+                        Marshal.FreeCoTaskMem(mem);
+                    }
+
+                    var menuIndex = GetMenuIndex(captions);
+                    if (menuIndex != null)
+                    {
+                        var value = Math.Min(Math.Max(menuIndex.Value, 0), menuItemCount);
+                        indexMenu = Convert.ToUInt32(value);
+                    }
+                }
+            }
 
             //  Set the first item id.
             var firstItemId = (uint)idCmdFirst;
@@ -362,6 +405,20 @@ namespace SharpShell.SharpContextMenu
         /// <summary>
         ///     Offers an opportunity to this instance to position itself in the context menu to be displayed by the system.
         /// </summary>
+        /// <param name="count">Number of items in the context menu to be displayed by the system.</param>
+        /// <returns>
+        ///     A value between zero and less than <paramref name="count" /> to choose a position,
+        ///     <c>null</c> to let the system position this instance.
+        ///     The default implementation returns <c>null</c>.
+        /// </returns>
+        protected virtual int? GetMenuIndex(int count)
+        {
+            return null;
+        }
+
+        /// <summary>
+        ///     Offers an opportunity to this instance to position itself in the context menu to be displayed by the system.
+        /// </summary>
         /// <param name="captions">
         ///     Captions of context menu entries to be displayed by the system.
         /// </param>
@@ -430,43 +487,6 @@ namespace SharpShell.SharpContextMenu
 
         [DllImport("User32.dll", SetLastError = true)]
         private static extern int GetMenuItemCount(IntPtr hMenu);
-
-        private int TryGetUserIndexMenu(IntPtr hMenu)
-        {
-            var count = GetMenuItemCount(hMenu);
-            if (count == -1)
-                return -1;
-
-            var captions = new string[count];
-
-            for (var i = 0u; i < count; i++)
-            {
-                var info = new MenuItemInfoW();
-                info.cbSize = (uint) Marshal.SizeOf(info);
-                info.fMask = (uint) MIIM.MIIM_STRING;
-
-                if (!GetMenuItemInfo(hMenu, i, true, ref info))
-                    continue; // not a string, e.g. separator, etc
-
-                var mem = Marshal.AllocCoTaskMem(((int) info.cch + 1) * sizeof(char));
-
-                info.dwTypeData = mem;
-                info.cch++;
-
-                if (GetMenuItemInfo(hMenu, i, true, ref info))
-                    captions[i] = Marshal.PtrToStringAuto(mem);
-
-                Marshal.FreeCoTaskMem(mem);
-            }
-
-            var index = GetMenuIndex(captions);
-            if (index == null)
-                return -1;
-
-            var value = Math.Min(Math.Max(index.Value, 0), count);
-
-            return value;
-        }
 
         #endregion
     }


### PR DESCRIPTION
…sition.

I am not exactly comfortable when it comes to Win32 programming but here's something that works and is very simple.

Best approach to me was to add a `reserved` parameter to the method, as opposed to some global var or refactor the method to use a queue instead of recursion.

The insertion process therefore happens only for outer items, the ones Windows Explorer context menu is trying to present.

Works as expected:

![2019-11-04_22-51-45](https://user-images.githubusercontent.com/1537591/68161223-b2e27780-ff55-11e9-8ad5-b87ea9c61ec1.png)

Should be tested in more advanced scenarios, however!
