### PR TITLE
fix: #362 Register PreviewHandler on Win10 190042ff

### DIFF
--- a/SharpShell/SharpShell/ServerRegistration/ServerRegistrationManager.cs
+++ b/SharpShell/SharpShell/ServerRegistration/ServerRegistrationManager.cs
@@ -442,6 +442,26 @@ namespace SharpShell.ServerRegistration
                             SetIconHandlerDefaultIcon(classesKey, associationClassName);
                     }
                 }
+                // On Win10 build 190042 ff it seems not to be enough to have an ShellEx\{8895b1c6-b41f-4c1c-a562-0d564250836f}
+                // below the associationClassName, you also need it below the assiociation key itself
+                if ( serverType == ServerType.ShellPreviewHander )
+                {
+                    using ( var classesKey = OpenClassesRoot(registrationType) )
+                    {
+                        //  For each one, create the server type key.
+                        foreach ( var serverKeyPath in associationAttribute.Associations.
+                                     Select(association => GetKeyForServerType(association, serverType, serverName)) )
+                        {
+                            using ( var serverKey = classesKey.CreateSubKey(serverKeyPath) )
+                            {
+                                //  If we failed to craete the server key, that's a big problem.
+                                if ( serverKey == null ) throw new InvalidOperationException($"Failed to create server key at '{serverKeyPath}'.");
+                                //  Set the server CLSID.
+                                serverKey.SetValue(null, serverClsid.ToRegistryString());
+                            }
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Alas described differently in MSDN https://docs.microsoft.com/en-us/windows/win32/shell/how-to-register-a-preview-handler
a PreviewHandler (additionally or only) needs ShellEx\{8895b1c6-b41f-4c1c-a562-0d564250836f} below the association key.

The MSDN sample https://github.com/microsoft/Windows-classic-samples/blob/27ffb0811ca761741502feaefdb591aebf592193/Samples/Win7Samples/winui/shell/appshellintegration/RecipePreviewHandler/dll.cpp#L206 creates the ShellEx key only below the association key, not the class name key.

See #362 
cc @AdmiralSnyder