### PR TITLE
build.ps1 improvements

### DIFF
--- a/SharpShell/build.ps1
+++ b/SharpShell/build.ps1
@@ -1,8 +1,7 @@
 # Run msbuild on the solution, in release mode.
-$msbuild = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
-$arguments = "/t:Rebuild /p:Configuration=Release $PSScriptRoot\SharpShell.sln"
+$msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+$arguments = @("/t:Clean,Restore,Build", "/p:Configuration=Release", "$PSScriptRoot\SharpShell.sln")
 
 # Run the command.
 Write-Host "Running: $msbuild $arguments"
 Start-Process -NoNewWindow -FilePath "$msbuild" -ArgumentList "$arguments"
-


### PR DESCRIPTION
- Calling to statically-placed `vswhere.exe` detects MSBuild automatically
- `t:Restore` allows immediate building from this script, without first needing to launch visual studio & reimport missing packages
- `$arguments` handled as string array, can now be passed directly to command without needing to duplicate content (not strictly needed with the new syntax, but the old ampersand call would've gotten use out of it)