### PR TITLE
PostBuildEvent compatability fix

### DIFF
--- a/SharpShellNativeBridge/SharpShellNativeBridge/SharpShellNativeBridge.vcxproj
+++ b/SharpShellNativeBridge/SharpShellNativeBridge/SharpShellNativeBridge.vcxproj
@@ -131,7 +131,7 @@ xcopy "$(TargetPath)" "$(ProjectDir)..\artifacts\build\SharpShellNativeBridge\" 
 xcopy "$(TargetPath)" "$(ProjectDir)..\artifacts\build\SharpShellNativeBridge\" /F /R /Y /I
 
 echo "Running x86 build..."
-msbuild "$(ProjectPath)" /p:PlatformTarget=Win32 /p:Configuration=$(ConfigurationName)</Command>
+msbuild "$(ProjectPath)" /p:PlatformTarget=x86 /p:Configuration=$(ConfigurationName)</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Writing project to NativeBridge Manifest Location</Message>
@@ -181,7 +181,7 @@ xcopy "$(TargetPath)" "$(ProjectDir)..\artifacts\build\SharpShellNativeBridge\" 
 xcopy "$(TargetPath)" "$(ProjectDir)..\artifacts\build\SharpShellNativeBridge\" /F /R /Y /I
 
 echo "Running x86 build..."
-msbuild "$(ProjectPath)" /p:PlatformTarget=Win32 /p:Configuration=$(ConfigurationName)</Command>
+msbuild "$(ProjectPath)" /p:PlatformTarget=x86 /p:Configuration=$(ConfigurationName)</Command>
       <Message>Writing project to NativeBridge Manifest Location</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
- PlatformTarget being set to Win32 breaks the build process for Platform Toolset v143, changing to x86 fixes this issue
- Leaving the platform target at v141 and making the adjustment still succeeds in building (though this was tested with Visual Studio 2022)
---
A minor pull request overall (though one that would've saved me headaches a few days ago), so I'll also ask: is there any particular reason the recommended SDKs/dependencies are staying relatively old? I'd usually assume stability, but with some of these assets/targets being legacy to the point of being unsupported, maybe there's something else to it I'm just not seeing