### PR TITLE
docs: fix srm's log path

### DIFF
--- a/docs/installing/installing.md
+++ b/docs/installing/installing.md
@@ -106,7 +106,7 @@ Use `srm` to enable logging, then attempt to run the installation again, then ch
 
 ```
 srm config LoggingMode File
-srm config LogPath '%TEMP%\SharpShell.log'
+srm config LogPath "%TEMP%\SharpShell.log"
 srm install <path.dll>
 srm config LoggingMode Disabled
 ```


### PR DESCRIPTION
Running `srm config LogPath '%TEMP%\SharpShell.log'` will get:
```
========================================
SharpShell - Server Registration Manager
========================================

Set LogPath to 'C:\Users\Chaoses\AppData\Local\Temp\SharpShell.log'
```
The path contains single quotes and no log file will be created.

It should be changed to `srm config LogPath "%TEMP%\SharpShell.log"`, which is parsed correctly:
```
========================================
SharpShell - Server Registration Manager
========================================

Set LogPath to C:\Users\Chaoses\AppData\Local\Temp\SharpShell.log
```

Related issue: https://github.com/dwmkerr/sharpshell/issues/280#issuecomment-481619591